### PR TITLE
Update for RFC8096

### DIFF
--- a/docs/mibs/IPV6-ICMP-MIB.txt
+++ b/docs/mibs/IPV6-ICMP-MIB.txt
@@ -7,13 +7,13 @@
      ipv6IfEntry                      FROM IPV6-MIB;
 
  ipv6IcmpMIB MODULE-IDENTITY
-     LAST-UPDATED "9801082155Z"
+     LAST-UPDATED "201702220000Z"
      ORGANIZATION "IETF IPv6 Working Group"
      CONTACT-INFO
        "           Dimitry Haskin
 
            Postal: Bay Networks, Inc.
-                   660 Techology Park Drive.
+                   660 Technology Park Drive.
                    Billerica, MA  01821
                    US
 
@@ -30,8 +30,27 @@
               Tel: +1-978-916-3816
            E-mail: sonishi@baynetworks.com"
      DESCRIPTION
-       "The MIB module for entities implementing
-        the ICMPv6."
+       "The obsolete MIB module for entities implementing
+        the ICMPv6.  Use the IP-MIB instead.
+
+        Copyright (c) 2017 IETF Trust and the persons
+        identified as authors of the code.  All rights
+        reserved.
+
+        Redistribution and use in source and binary
+        forms, with or without modification, is permitted
+        pursuant to, and subject to the license terms contained
+        in, the Simplified BSD License set forth in Section
+        4.c of the IETF Trust's Legal Provisions Relating to
+        IETF Documents
+        (http://trustee.ietf.org/license-info)."
+     REVISION "201702220000Z"
+     DESCRIPTION
+       "Obsoleting this MIB module; it has been replaced by
+       the revised IP-MIB (RFC 4293)."
+     REVISION "9801082155Z"
+     DESCRIPTION
+       "First revision, published as RFC 2466"
      ::= { mib-2 56 }
 
  -- the ICMPv6 group
@@ -43,17 +62,20 @@
  ipv6IfIcmpTable OBJECT-TYPE
      SYNTAX     SEQUENCE OF Ipv6IfIcmpEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-      "IPv6 ICMP statistics. This table contains statistics
+      "IPv6 ICMP statistics.  This table contains statistics
       of ICMPv6 messages that are received and sourced by
-      the entity."
+      the entity.
+
+      This table is obsolete because systems were found
+      not to maintain these statistics per-interface."
      ::= { ipv6IcmpMIBObjects 1 }
 
  ipv6IfIcmpEntry OBJECT-TYPE
      SYNTAX     Ipv6IfIcmpEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "An ICMPv6 statistics entry containing
       objects at a particular IPv6 interface.
@@ -63,10 +85,13 @@
       is addressed which may not be necessarily
       the input interface for the message.
 
-      Similarly,  the sending interface is
+      Similarly, the sending interface is
       the interface that sources a given
       ICMP message which is usually but not
-      necessarily the output interface for the message."
+      necessarily the output interface for the message.
+
+      This table is obsolete because systems were found
+      not to maintain these statistics per-interface."
      AUGMENTS { ipv6IfEntry }
      ::= { ipv6IfIcmpTable 1 }
 
@@ -145,176 +170,231 @@
  ipv6IfIcmpInMsgs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The total number of ICMP messages received
       by the interface which includes all those
-      counted by ipv6IfIcmpInErrors. Note that this
+      counted by ipv6IfIcmpInErrors.  Note that this
       interface is the interface to which the
       ICMP messages were addressed which may not be
-      necessarily the input interface for the messages."
+      necessarily the input interface for the messages.
+
+      This object has been obsoleted by IP-MIB::icmpStatsInMsgs."
      ::= { ipv6IfIcmpEntry 1 }
 
  ipv6IfIcmpInErrors OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP messages which the interface
       received but determined as having ICMP-specific
-      errors (bad ICMP checksums, bad length, etc.)."
+      errors (bad ICMP checksums, bad length, etc.).
+
+      This object has been obsoleted by IP-MIB::icmpStatsInErrors."
      ::= { ipv6IfIcmpEntry 2 }
 
  ipv6IfIcmpInDestUnreachs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Destination Unreachable
-      messages received by the interface."
+      messages received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 3 }
 
  ipv6IfIcmpInAdminProhibs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP destination
       unreachable/communication administratively
-      prohibited messages received by the interface."
+
+      prohibited messages received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 4 }
 
  ipv6IfIcmpInTimeExcds OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Time Exceeded messages
-       received by the interface."
+       received by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 5 }
 
  ipv6IfIcmpInParmProblems OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Parameter Problem messages
-       received by the interface."
+       received by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 6 }
 
  ipv6IfIcmpInPktTooBigs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Packet Too Big messages
-      received by the interface."
+      received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 7 }
 
  ipv6IfIcmpInEchos OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Echo (request) messages
-       received by the interface."
+
+       received by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 8 }
 
  ipv6IfIcmpInEchoReplies OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Echo Reply messages received
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 9 }
 
  ipv6IfIcmpInRouterSolicits OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Router Solicit messages
-       received by the interface."
+       received by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 10 }
 
  ipv6IfIcmpInRouterAdvertisements OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Router Advertisement messages
-      received by the interface."
+      received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 11 }
 
  ipv6IfIcmpInNeighborSolicits OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Neighbor Solicit messages
-       received by the interface."
+
+       received by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 12 }
 
  ipv6IfIcmpInNeighborAdvertisements OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Neighbor Advertisement
-      messages received by the interface."
+      messages received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 13 }
 
  ipv6IfIcmpInRedirects OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of Redirect messages received
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 14 }
 
  ipv6IfIcmpInGroupMembQueries OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Query
-      messages received by the interface."
+      messages received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 15}
 
  ipv6IfIcmpInGroupMembResponses OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Response messages
-      received by the interface."
+
+      received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 16}
 
   ipv6IfIcmpInGroupMembReductions OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Reduction messages
-      received by the interface."
+      received by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 17}
 
  ipv6IfIcmpOutMsgs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The total number of ICMP messages which this
       interface attempted to send.  Note that this counter
-      includes all those counted by icmpOutErrors."
+      includes all those counted by icmpOutErrors.
+
+      This object has been obsoleted by IP-MIB::icmpStatsOutMsgs."
      ::= { ipv6IfIcmpEntry 18 }
 
  ipv6IfIcmpOutErrors OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP messages which this interface did
       not send due to problems discovered within ICMP
@@ -323,144 +403,190 @@
       such as the inability of IPv6 to route the resultant
       datagram.  In some implementations there may be no
       types of error which contribute to this counter's
-      value."
+      value.
+
+      This object has been obsoleted by IP-MIB::icmpStatsOutErrors."
      ::= { ipv6IfIcmpEntry 19 }
 
  ipv6IfIcmpOutDestUnreachs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Destination Unreachable
+      messages sent by the interface.
 
-      messages sent by the interface."
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 20 }
 
  ipv6IfIcmpOutAdminProhibs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "Number of ICMP dest unreachable/communication
-       administratively prohibited messages sent."
+       administratively prohibited messages sent.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 21 }
 
  ipv6IfIcmpOutTimeExcds OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Time Exceeded messages sent
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 22 }
 
  ipv6IfIcmpOutParmProblems OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Parameter Problem messages
-      sent by the interface."
+      sent by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 23 }
 
  ipv6IfIcmpOutPktTooBigs OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Packet Too Big messages sent
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 24 }
 
  ipv6IfIcmpOutEchos OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Echo (request) messages sent
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 25 }
 
  ipv6IfIcmpOutEchoReplies OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Echo Reply messages sent
-      by the interface."
+      by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 26 }
 
  ipv6IfIcmpOutRouterSolicits OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Router Solicitation messages
-       sent by the interface."
+       sent by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 27 }
 
  ipv6IfIcmpOutRouterAdvertisements OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Router Advertisement messages
-      sent by the interface."
+      sent by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 28 }
 
  ipv6IfIcmpOutNeighborSolicits OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Neighbor Solicitation
-       messages sent by the interface."
+       messages sent by the interface.
+
+       This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+       in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 29 }
 
  ipv6IfIcmpOutNeighborAdvertisements OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMP Neighbor Advertisement
-      messages sent by the interface."
+      messages sent by the interface.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 30 }
 
  ipv6IfIcmpOutRedirects OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-      "The number of Redirect messages sent. For
+      "The number of Redirect messages sent.  For
       a host, this object will always be zero,
-      since hosts do not send redirects."
+      since hosts do not send redirects.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 31 }
 
  ipv6IfIcmpOutGroupMembQueries OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Query
-      messages sent."
+      messages sent.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 32}
 
  ipv6IfIcmpOutGroupMembResponses OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Response
-      messages sent."
+      messages sent.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 33}
 
  ipv6IfIcmpOutGroupMembReductions OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The number of ICMPv6 Group Membership Reduction
-      messages sent."
+      messages sent.
+
+      This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+      in the row corresponding to this message type."
      ::= { ipv6IfIcmpEntry 34}
 
 -- conformance information
@@ -475,10 +601,13 @@ ipv6IcmpGroups
 -- compliance statements
 
 ipv6IcmpCompliance MODULE-COMPLIANCE
-    STATUS  current
+    STATUS  obsolete
     DESCRIPTION
       "The compliance statement for SNMPv2 entities which
-      implement ICMPv6."
+      implement ICMPv6.
+
+      This compliance statement has been obsoleted by
+      IP-MIB::ipMIBCompliance2."
     MODULE  -- this module
         MANDATORY-GROUPS { ipv6IcmpGroup }
     ::= { ipv6IcmpCompliances 1 }
@@ -520,10 +649,12 @@ ipv6IcmpGroup OBJECT-GROUP
                 ipv6IfIcmpOutGroupMembResponses,
                 ipv6IfIcmpOutGroupMembReductions
               }
-    STATUS    current
+    STATUS    obsolete
     DESCRIPTION
          "The ICMPv6 group of objects providing information
-          specific to ICMPv6."
+          specific to ICMPv6.
+
+          This group has been obsoleted by IP-MIB::icmpStatsGroup."
     ::= { ipv6IcmpGroups 1 }
 
  END

--- a/docs/mibs/IPV6-MIB.txt
+++ b/docs/mibs/IPV6-MIB.txt
@@ -13,13 +13,13 @@
      Ipv6IfIndexOrZero                     FROM IPV6-TC;
 
  ipv6MIB MODULE-IDENTITY
-     LAST-UPDATED "9802052155Z"
+     LAST-UPDATED "201702220000Z"
      ORGANIZATION "IETF IPv6 Working Group"
      CONTACT-INFO
        "           Dimitry Haskin
 
            Postal: Bay Networks, Inc.
-                   660 Techology Park Drive.
+                   660 Technology Park Drive.
                    Billerica, MA  01821
 
                    US
@@ -37,8 +37,26 @@
               Tel: +1-978-916-3816
            E-mail: sonishi@baynetworks.com"
      DESCRIPTION
-       "The MIB module for entities implementing the IPv6
-        protocol."
+       "The obsolete MIB module for entities implementing the IPv6
+        protocol.  Use the IP-MIB or IP-FORWARD-MIB instead.
+
+        Copyright (c) 2017 IETF Trust and the persons identified
+        as authors of the code. All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Simplified BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (http://trustee.ietf.org/license-info)."
+     REVISION "201702220000Z"
+     DESCRIPTION
+       "Obsoleting this MIB module; it has been replaced by
+       the revised IP-MIB (RFC 4293) and IP-FORWARD-MIB
+       (RFC 4292)."
+     REVISION "9802052155Z"
+     DESCRIPTION
+       "First revision, published as RFC 2465"
      ::= { mib-2 55 }
 
  -- the IPv6 general group
@@ -53,7 +71,7 @@
                   notForwarding(2)  -- a router
                  }
       MAX-ACCESS read-write
-      STATUS     current
+      STATUS     obsolete
       DESCRIPTION
         "The indication of whether this entity is acting
         as an IPv6 router in respect to the forwarding of
@@ -67,41 +85,52 @@
         Accordingly, it is appropriate for an agent to
         return a `wrongValue' response if a management
         station attempts to change this object to an
-        inappropriate value."
+        inappropriate value.
+
+        This object is obsoleted by IP-MIB::ipv6IpForwarding."
       ::= { ipv6MIBObjects 1 }
 
  ipv6DefaultHopLimit OBJECT-TYPE
      SYNTAX      INTEGER(0..255)
      MAX-ACCESS  read-write
-      STATUS     current
+      STATUS     obsolete
      DESCRIPTION
         "The default value inserted into the Hop Limit
         field of the IPv6 header of datagrams originated
         at this entity, whenever a Hop Limit value is not
-        supplied by the transport layer protocol."
+        supplied by the transport layer protocol.
+
+        This object is obsoleted by IP-MIB::ipv6IpDefaultHopLimit."
      DEFVAL  { 64 }
      ::= { ipv6MIBObjects 2 }
 
 ipv6Interfaces OBJECT-TYPE
      SYNTAX      Unsigned32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The number of IPv6 interfaces (regardless of
-        their current state) present on this system."
+        their current state) present on this system.
+
+        This object is obsolete; there is no direct replacement,
+        but its value can be derived from the number of rows
+        in the IP-MIB::ipv6InterfaceTable."
      ::= { ipv6MIBObjects 3 }
 
 ipv6IfTableLastChange OBJECT-TYPE
      SYNTAX      TimeStamp
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The value of sysUpTime at the time of the last
        insertion or removal of an entry in the
-       ipv6IfTable. If the number of entries has been
+       ipv6IfTable.  If the number of entries has been
        unchanged since the last re-initialization of
        the local network management subsystem, then this
-       object contains a zero value."
+       object contains a zero value.
+
+       This object is obsoleted by
+       IP-MIB::ipv6InterfaceTableLastChange."
      ::= { ipv6MIBObjects 4 }
 
 -- the IPv6 Interfaces table
@@ -109,7 +138,7 @@ ipv6IfTableLastChange OBJECT-TYPE
 ipv6IfTable OBJECT-TYPE
      SYNTAX     SEQUENCE OF Ipv6IfEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "The IPv6 Interfaces table contains information
        on the entity's internetwork-layer interfaces.
@@ -117,16 +146,20 @@ ipv6IfTable OBJECT-TYPE
        layer attachment to the layer immediately below
 
        IPv6 including internet layer 'tunnels', such as
-       tunnels over IPv4 or IPv6 itself."
+       tunnels over IPv4 or IPv6 itself.
+
+       This table is obsoleted by IP-MIB::ipv6InterfaceTable."
      ::= { ipv6MIBObjects 5 }
 
  ipv6IfEntry OBJECT-TYPE
      SYNTAX     Ipv6IfEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "An interface entry containing objects
-        about a particular IPv6 interface."
+        about a particular IPv6 interface.
+
+        This object is obsoleted by IP-MIB::ipv6InterfaceEntry."
      INDEX   { ipv6IfIndex }
      ::= { ipv6IfTable 1 }
 
@@ -147,105 +180,126 @@ ipv6IfTable OBJECT-TYPE
  ipv6IfIndex OBJECT-TYPE
      SYNTAX     Ipv6IfIndex
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "A unique non-zero value identifying
-        the particular IPv6 interface."
+        the particular IPv6 interface.
+
+        This object is obsoleted.  In the IP-MIB,
+        interfaces are simply identified by IfIndex."
      ::= { ipv6IfEntry 1 }
 
  ipv6IfDescr OBJECT-TYPE
      SYNTAX     DisplayString
      MAX-ACCESS read-write
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "A textual string containing information about the
        interface.  This string may be set by the network
-       management system."
+       management system.
+
+       This object is obsoleted by IF-MIB::ifDescr."
      ::= { ipv6IfEntry 2 }
 
  ipv6IfLowerLayer OBJECT-TYPE
     SYNTAX      VariablePointer
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "This object identifies the protocol layer over
        which this network interface operates.  If this
        network interface operates over the data-link
        layer, then the value of this object refers to an
-       instance of ifIndex [6]. If this network interface
+       instance of ifIndex [RFC1573].  If this network interface
        operates over an IPv4 interface, the value of this
-       object refers to an instance of ipAdEntAddr [3].
+       object refers to an instance of ipAdEntAddr [RFC1213].
 
        If this network interface operates over another
        IPv6 interface, the value of this object refers to
        an instance of ipv6IfIndex.  If this network
        interface is not currently operating over an active
        protocol layer, then the value of this object
-       should be set to the OBJECT ID { 0 0 }."
+       should be set to the OBJECT ID { 0 0 }.
+
+       This object is obsolete.  The IF-STACK-TABLE may
+       be used to express relationships between interfaces."
     ::= { ipv6IfEntry 3 }
 
  ipv6IfEffectiveMtu OBJECT-TYPE
     SYNTAX      Unsigned32
     UNITS       "octets"
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The size of the largest IPv6 packet which can be
       sent/received on the interface, specified in
-      octets."
+      octets.
+
+      This object is obsolete.  The value of IF-MIB::ifMtu
+      for the corresponding value of ifIndex represents the
+      MTU of the interface."
  ::= { ipv6IfEntry 4 }
 
  ipv6IfReasmMaxSize OBJECT-TYPE
     SYNTAX      Unsigned32 (0..65535)
     UNITS       "octets"
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The size of the largest IPv6 datagram which this
       entity can re-assemble from incoming IPv6 fragmented
-      datagrams received on this interface."
+      datagrams received on this interface.
+
+      This object is obsoleted by IP-MIB::ipv6InterfaceReasmMaxSize."
  ::= { ipv6IfEntry 5 }
 
  ipv6IfIdentifier OBJECT-TYPE
      SYNTAX      Ipv6AddressIfIdentifier
      MAX-ACCESS  read-write
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The Interface Identifier for this interface that
-
         is (at least) unique on the link this interface is
-        attached to. The Interface Identifier is combined
+        attached to.  The Interface Identifier is combined
         with an address prefix to form an interface address.
 
         By default, the Interface Identifier is autoconfigured
         according to the rules of the link type this
-        interface is attached to."
+        interface is attached to.
+
+        This object is obsoleted by IP-MIB::ipv6InterfaceIdentifier."
      ::= { ipv6IfEntry 6 }
 
  ipv6IfIdentifierLength OBJECT-TYPE
      SYNTAX      INTEGER (0..64)
      UNITS       "bits"
      MAX-ACCESS  read-write
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
-       "The length of the Interface Identifier in bits."
+       "The length of the Interface Identifier in bits.
+
+       This object is obsolete.  It can be derived from the length
+       of IP-MIB::ipv6InterfaceIdentifier; Interface Identifiers
+       that are not an even number of octets are not supported."
      ::= { ipv6IfEntry 7 }
 
  ipv6IfPhysicalAddress OBJECT-TYPE
      SYNTAX      PhysAddress
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
-       "The interface's physical address. For example, for
+       "The interface's physical address.  For example, for
        an IPv6 interface attached to an 802.x link, this
-       object normally contains a MAC address. Note that
+       object normally contains a MAC address.  Note that
        in some cases this address may differ from the
        address of the interface's protocol sub-layer.  The
        interface's media-specific MIB must define the bit
        and byte ordering and the format of the value of
-       this object. For interfaces which do not have such
+       this object.  For interfaces which do not have such
        an address (e.g., a serial line), this object should
-       contain an octet string of zero length."
+       contain an octet string of zero length.
+
+       This object is obsoleted by IF-MIB::ifPhysAddress."
      ::= { ipv6IfEntry 8 }
 
 ipv6IfAdminStatus OBJECT-TYPE
@@ -254,16 +308,19 @@ ipv6IfAdminStatus OBJECT-TYPE
              down(2)
             }
     MAX-ACCESS  read-write
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The desired state of the interface.  When a managed
-      system initializes,  all IPv6 interfaces start with
+      system initializes, all IPv6 interfaces start with
       ipv6IfAdminStatus in the down(2) state.  As a result
       of either explicit management action or per
       configuration information retained by the managed
+      system, ipv6IfAdminStatus is then changed to
+      the up(1) state (or remains in the down(2) state).
 
-      system,  ipv6IfAdminStatus is then changed to
-      the up(1) state (or remains in the down(2) state)."
+      This object is obsolete.  IPv6 does not have a
+      separate admin status; the admin status of the
+      interface is represented by IF-MIB::ifAdminStatus."
     ::= { ipv6IfEntry 9 }
 
 ipv6IfOperStatus OBJECT-TYPE
@@ -274,6 +331,7 @@ ipv6IfOperStatus OBJECT-TYPE
              noIfIdentifier(3), -- no interface identifier
 
                                 -- status can not be
+
                                 -- determined for some
              unknown(4),        -- reason
 
@@ -281,7 +339,7 @@ ipv6IfOperStatus OBJECT-TYPE
              notPresent(5)      -- missing
             }
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The current operational state of the interface.
       The noIfIdentifier(3) state indicates that no valid
@@ -297,21 +355,27 @@ ipv6IfOperStatus OBJECT-TYPE
       fault that prevents it from going to the up(1) state;
       it should remain in the notPresent(5) state if
       the interface has missing (typically, lower layer)
-      components."
+      components.
+
+      This object is obsolete.  IPv6 does not have a
+      separate operational status; the operational status of the
+      interface is represented by IF-MIB::ifOperStatus."
     ::= { ipv6IfEntry 10 }
 
 ipv6IfLastChange OBJECT-TYPE
     SYNTAX      TimeStamp
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
         "The value of sysUpTime at the time the interface
         entered its current operational state.  If the
         current state was entered prior to the last
         re-initialization of the local network management
-
         subsystem, then this object contains a zero
-        value."
+        value.
+
+        This object is obsolete.  The last change of
+        IF-MIB::ifOperStatus is represented by IF-MIB::ifLastChange."
     ::= { ipv6IfEntry 11 }
 
  --  IPv6 Interface Statistics table
@@ -319,18 +383,22 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6IfStatsTable OBJECT-TYPE
      SYNTAX     SEQUENCE OF Ipv6IfStatsEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-         "IPv6 interface traffic statistics."
+         "IPv6 interface traffic statistics.
+
+         This table is obsoleted by the IP-MIB::ipIfStatsTable."
      ::= { ipv6MIBObjects 6 }
 
  ipv6IfStatsEntry OBJECT-TYPE
      SYNTAX     Ipv6IfStatsEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
          "An interface statistics entry containing objects
-         at a particular IPv6 interface."
+         at a particular IPv6 interface.
+
+         This object is obsoleted by the IP-MIB::ipIfStatsEntry."
      AUGMENTS { ipv6IfEntry }
      ::= { ipv6IfStatsTable 1 }
 
@@ -358,9 +426,9 @@ ipv6IfLastChange OBJECT-TYPE
          ipv6IfStatsOutRequests
              Counter32,
          ipv6IfStatsOutDiscards
-
              Counter32,
          ipv6IfStatsOutFragOKs
+
              Counter32,
          ipv6IfStatsOutFragFails
              Counter32,
@@ -381,48 +449,59 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6IfStatsInReceives OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The total number of input datagrams received by
-        the interface, including those received in error."
+        the interface, including those received in error.
+
+        This object is obsoleted by IP-MIB::ipIfStatsHCInReceives."
      ::= { ipv6IfStatsEntry 1 }
 
  ipv6IfStatsInHdrErrors OBJECT-TYPE
      SYNTAX     Counter32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The number of input datagrams discarded due to
         errors in their IPv6 headers, including version
         number mismatch, other format errors, hop count
         exceeded, errors discovered in processing their
-        IPv6 options, etc."
+        IPv6 options, etc.
+
+        This object is obsoleted by IP-MIB::ipIfStatsInHdrErrors."
      ::= { ipv6IfStatsEntry 2 }
 
  ipv6IfStatsInTooBigErrors OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The number of input datagrams that could not be
+
        forwarded because their size exceeded the link MTU
-       of outgoing interface."
+       of outgoing interface.
+
+       This object is obsoleted.  It was not replicated in the
+       IP-MIB due to feedback that systems did not retain the
+       incoming interface of a packet that failed fragmentation."
      ::= { ipv6IfStatsEntry 3 }
 
  ipv6IfStatsInNoRoutes OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of input datagrams discarded because no
          route could be found to transmit them to their
-         destination."
+         destination.
+
+         This object is obsoleted by IP-MIB::ipIfStatsInNoRoutes."
      ::= { ipv6IfStatsEntry 4 }
 
  ipv6IfStatsInAddrErrors OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of input datagrams discarded because
         the IPv6 address in their IPv6 header's destination
@@ -433,62 +512,73 @@ ipv6IfLastChange OBJECT-TYPE
         entities which are not IPv6 routers and therefore
         do not forward datagrams, this counter includes
         datagrams discarded because the destination address
-        was not a local address."
+        was not a local address.
+
+        This object is obsoleted by IP-MIB::ipIfStatsInAddrErrors."
      ::= { ipv6IfStatsEntry 5 }
 
  ipv6IfStatsInUnknownProtos OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of locally-addressed datagrams
         received successfully but discarded because of an
-        unknown or unsupported protocol. This counter is
+        unknown or unsupported protocol.  This counter is
         incremented at the interface to which these
+
         datagrams were addressed which might not be
         necessarily the input interface for some of
-        the datagrams."
+        the datagrams.
+
+        This object is obsoleted by IP-MIB::ipIfStatsInUnknownProtos."
      ::= { ipv6IfStatsEntry 6 }
 
  ipv6IfStatsInTruncatedPkts OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of input datagrams discarded because
-         datagram frame didn't carry enough data."
+         datagram frame didn't carry enough data.
+
+         This object is obsoleted by IP-MIB::ipIfStatsInTruncatedPkts."
      ::= { ipv6IfStatsEntry 7 }
 
  ipv6IfStatsInDiscards OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of input IPv6 datagrams for which no
         problems were encountered to prevent their
         continued processing, but which were discarded
         (e.g., for lack of buffer space).  Note that this
         counter does not include any datagrams discarded
-        while awaiting re-assembly."
+        while awaiting re-assembly.
+
+        This object is obsoleted by IP-MIB::ipIfStatsInDiscards."
      ::= { ipv6IfStatsEntry 8 }
 
  ipv6IfStatsInDelivers OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
       "The total number of datagrams successfully
       delivered to IPv6 user-protocols (including ICMP).
       This counter is incremented at the interface to
       which these datagrams were addressed which might
       not be necessarily the input interface for some of
-      the datagrams."
+      the datagrams.
+
+      This object is obsoleted by IP-MIB::ipIfStatsHCInDelivers."
      ::= { ipv6IfStatsEntry 9 }
 
  ipv6IfStatsOutForwDatagrams OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of output datagrams which this
         entity received and forwarded to their final
@@ -498,25 +588,30 @@ ipv6IfLastChange OBJECT-TYPE
         via this entity, and the Source-Route
         processing was successful.  Note that for
         a successfully forwarded datagram the counter
-        of the outgoing interface is incremented."
+        of the outgoing interface is incremented.
+
+        This object is obsoleted by
+        IP-MIB::ipIfStatsHCOutForwDatagrams."
      ::= { ipv6IfStatsEntry 10 }
 
  ipv6IfStatsOutRequests OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
       "The total number of IPv6 datagrams which local IPv6
       user-protocols (including ICMP) supplied to IPv6 in
       requests for transmission.  Note that this counter
       does not include any datagrams counted in
-      ipv6IfStatsOutForwDatagrams."
+      ipv6IfStatsOutForwDatagrams.
+
+      This object is obsoleted by IP-MIB::ipIfStatsHCOutRequests."
      ::= { ipv6IfStatsEntry 11 }
 
  ipv6IfStatsOutDiscards OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
          "The number of output IPv6 datagrams for which no
          problem was encountered to prevent their
@@ -524,67 +619,79 @@ ipv6IfLastChange OBJECT-TYPE
          discarded (e.g., for lack of buffer space).  Note
          that this counter would include datagrams counted
          in ipv6IfStatsOutForwDatagrams if any such packets
-         met this (discretionary) discard criterion."
+         met this (discretionary) discard criterion.
+
+         This object is obsoleted by IP-MIB::ipIfStatsOutDiscards."
      ::= { ipv6IfStatsEntry 12 }
 
  ipv6IfStatsOutFragOKs OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of IPv6 datagrams that have been
-         successfully fragmented at this output interface."
+         successfully fragmented at this output interface.
+
+         This object is obsoleted by IP-MIB::ipIfStatsOutFragOKs."
      ::= { ipv6IfStatsEntry 13 }
 
  ipv6IfStatsOutFragFails OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of IPv6 datagrams that have been
          discarded because they needed to be fragmented
-         at this output interface but could not be."
+         at this output interface but could not be.
+
+         This object is obsoleted by IP-MIB::ipIfStatsOutFragFails."
      ::= { ipv6IfStatsEntry 14 }
 
  ipv6IfStatsOutFragCreates OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of output datagram fragments that have
          been generated as a result of fragmentation at
-         this output interface."
+         this output interface.
+
+         This object is obsoleted by IP-MIB::ipIfStatsOutFragCreates."
      ::= { ipv6IfStatsEntry 15 }
 
  ipv6IfStatsReasmReqds OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of IPv6 fragments received which needed
          to be reassembled at this interface.  Note that this
          counter is incremented at the interface to which
          these fragments were addressed which might not
          be necessarily the input interface for some of
-         the fragments."
+         the fragments.
+
+         This object is obsoleted by IP-MIB::ipIfStatsReasmReqds."
      ::= { ipv6IfStatsEntry 16 }
 
  ipv6IfStatsReasmOKs OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The number of IPv6 datagrams successfully
        reassembled.  Note that this counter is incremented
        at the interface to which these datagrams were
        addressed which might not be necessarily the input
-       interface for some of the fragments."
+       interface for some of the fragments.
+
+       This object is obsoleted by IP-MIB::ipIfStatsReasmOKs."
      ::= { ipv6IfStatsEntry 17 }
 
  ipv6IfStatsReasmFails OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of failures detected by the IPv6 re-
         assembly algorithm (for whatever reason: timed
@@ -596,25 +703,31 @@ ipv6IfLastChange OBJECT-TYPE
         This counter is incremented at the interface to which
         these fragments were addressed which might not be
         necessarily the input interface for some of the
-        fragments."
+        fragments.
+
+        This object is obsoleted by IP-MIB::ipIfStatsReasmFails."
      ::= { ipv6IfStatsEntry 18 }
 
  ipv6IfStatsInMcastPkts OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The number of multicast packets received
-         by the interface"
+         by the interface
+
+         This object is obsoleted by IP-MIB::ipIfStatsHCInMcastPkts."
      ::= { ipv6IfStatsEntry 19 }
 
  ipv6IfStatsOutMcastPkts OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "The number of multicast packets transmitted
-         by the interface"
+         by the interface
+
+         This object is obsoleted by IP-MIB::ipIfStatsHCOutMcastPkts."
      ::= { ipv6IfStatsEntry 20 }
 
  -- Address Prefix table
@@ -626,79 +739,93 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6AddrPrefixTable OBJECT-TYPE
      SYNTAX  SEQUENCE OF Ipv6AddrPrefixEntry
      MAX-ACCESS  not-accessible
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
          "The list of IPv6 address prefixes of
-         IPv6 interfaces."
+         IPv6 interfaces.
+
+         This table is obsoleted by IP-MIB::ipAddressPrefixTable."
      ::= { ipv6MIBObjects 7 }
 
  ipv6AddrPrefixEntry OBJECT-TYPE
      SYNTAX  Ipv6AddrPrefixEntry
      MAX-ACCESS  not-accessible
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
          "An interface entry containing objects of
-         a particular IPv6 address prefix."
+         a particular IPv6 address prefix.
+
+         This entry is obsoleted by IP-MIB::ipAddressPrefixEntry."
      INDEX   { ipv6IfIndex,
                ipv6AddrPrefix,
                ipv6AddrPrefixLength }
      ::= { ipv6AddrPrefixTable 1 }
 
  Ipv6AddrPrefixEntry ::= SEQUENCE {
-
       ipv6AddrPrefix                     Ipv6AddressPrefix,
-      ipv6AddrPrefixLength               INTEGER (0..128),
+      ipv6AddrPrefixLength               INTEGER,
       ipv6AddrPrefixOnLinkFlag           TruthValue,
       ipv6AddrPrefixAutonomousFlag       TruthValue,
       ipv6AddrPrefixAdvPreferredLifetime Unsigned32,
       ipv6AddrPrefixAdvValidLifetime     Unsigned32
+
      }
 
  ipv6AddrPrefix OBJECT-TYPE
      SYNTAX      Ipv6AddressPrefix
      MAX-ACCESS  not-accessible
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
-       "The prefix associated with the this interface."
+       "The prefix associated with the this interface.
+
+       This object is obsoleted by IP-MIB::ipAddressPrefixPrefix."
      ::= { ipv6AddrPrefixEntry 1 }
 
  ipv6AddrPrefixLength OBJECT-TYPE
      SYNTAX      INTEGER (0..128)
      UNITS       "bits"
      MAX-ACCESS  not-accessible
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
-       "The length of the prefix (in bits)."
+       "The length of the prefix (in bits).
+
+       This object is obsoleted by IP-MIB::ipAddressPrefixLength."
      ::= { ipv6AddrPrefixEntry 2 }
 
  ipv6AddrPrefixOnLinkFlag OBJECT-TYPE
      SYNTAX      TruthValue
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "This object has the value 'true(1)', if this
-       prefix can be used  for on-link determination
-       and the value 'false(2)' otherwise."
+       prefix can be used for on-link determination
+       and the value 'false(2)' otherwise.
+
+       This object is obsoleted by IP-MIB::ipAddressPrefixOnLinkFlag."
      ::= { ipv6AddrPrefixEntry 3 }
 
  ipv6AddrPrefixAutonomousFlag OBJECT-TYPE
      SYNTAX      TruthValue
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
-       "Autonomous address configuration flag. When
+       "Autonomous address configuration flag.  When
        true(1), indicates that this prefix can be used
        for autonomous address configuration (i.e. can
        be used to form a local interface address).
        If false(2), it is not used to autoconfigure
-       a local interface address."
+       a local interface address.
+
+       This object is obsoleted by
+
+       IP-MIB::ipAddressPrefixAutonomousFlag."
      ::= { ipv6AddrPrefixEntry 4 }
 
  ipv6AddrPrefixAdvPreferredLifetime OBJECT-TYPE
      SYNTAX      Unsigned32
      UNITS       "seconds"
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
         "It is the length of time in seconds that this
         prefix will remain preferred, i.e. time until
@@ -708,14 +835,17 @@ ipv6IfLastChange OBJECT-TYPE
         The address generated from a deprecated prefix
         should no longer be used as a source address in
         new communications, but packets received on such
-        an interface are processed as expected."
+        an interface are processed as expected.
+
+        This object is obsoleted by
+        IP-MIB::ipAddressPrefixAdvPreferredLifetime."
      ::= { ipv6AddrPrefixEntry 5 }
 
  ipv6AddrPrefixAdvValidLifetime OBJECT-TYPE
      SYNTAX      Unsigned32
      UNITS       "seconds"
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "It is the length of time in seconds that this
        prefix will remain valid, i.e. time until
@@ -724,7 +854,10 @@ ipv6IfLastChange OBJECT-TYPE
 
        The address generated from an invalidated prefix
        should not appear as the destination or source
-       address of a packet."
+       address of a packet.
+
+       This object is obsoleted by
+       IP-MIB::ipAddressPrefixAdvValidLifetime."
      ::= { ipv6AddrPrefixEntry 6 }
 
  -- the IPv6 Address table
@@ -735,19 +868,23 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6AddrTable OBJECT-TYPE
     SYNTAX      SEQUENCE OF Ipv6AddrEntry
     MAX-ACCESS  not-accessible
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The table of addressing information relevant to
-      this node's interface addresses."
+      this node's interface addresses.
+
+      This table is obsoleted by IP-MIB::ipAddressTable."
     ::= { ipv6MIBObjects 8 }
 
  ipv6AddrEntry OBJECT-TYPE
     SYNTAX      Ipv6AddrEntry
     MAX-ACCESS  not-accessible
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
         "The addressing information for one of this
-        node's interface addresses."
+        node's interface addresses.
+
+        This entry is obsoleted by IP-MIB::ipAddressEntry."
     INDEX   { ipv6IfIndex, ipv6AddrAddress }
     ::= { ipv6AddrTable 1 }
 
@@ -763,20 +900,26 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6AddrAddress OBJECT-TYPE
     SYNTAX      Ipv6Address
     MAX-ACCESS  not-accessible
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The IPv6 address to which this entry's addressing
-      information pertains."
+      information pertains.
+
+      This object is obsoleted by IP-MIB::ipAddressAddr."
     ::= { ipv6AddrEntry 1 }
 
  ipv6AddrPfxLength OBJECT-TYPE
     SYNTAX      INTEGER(0..128)
     UNITS       "bits"
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "The length of the prefix (in bits) associated with
-      the IPv6 address of this entry."
+      the IPv6 address of this entry.
+
+      This object is obsoleted by the IP-MIB::ipAddressPrefixLength
+      in the row of the IP-MIB::ipAddressPrefixTable to which the
+      IP-MIB::ipAddressPrefix points."
     ::= { ipv6AddrEntry 2 }
 
  ipv6AddrType OBJECT-TYPE
@@ -794,23 +937,28 @@ ipv6IfLastChange OBJECT-TYPE
          unknown(3)     -- for some reason.
        }
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
-       "The type of address. Note that 'stateless(1)'
+       "The type of address.  Note that 'stateless(1)'
        refers to an address that was statelessly
        autoconfigured; 'stateful(2)' refers to a address
        which was acquired by via a stateful protocol
-       (e.g. DHCPv6, manual configuration)."
+       (e.g. DHCPv6, manual configuration).
+
+       This object is obsoleted by IP-MIB::ipAddressOrigin."
     ::= { ipv6AddrEntry 3 }
 
  ipv6AddrAnycastFlag OBJECT-TYPE
      SYNTAX      TruthValue
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "This object has the value 'true(1)', if this
        address is an anycast address and the value
-       'false(2)' otherwise."
+       'false(2)' otherwise.
+
+       This object is obsoleted by a value of 'anycast(2)'
+       in IP-MIB::ipAddressType."
      ::= { ipv6AddrEntry 4 }
 
  ipv6AddrStatus OBJECT-TYPE
@@ -823,7 +971,7 @@ ipv6IfLastChange OBJECT-TYPE
                           -- for some reason.
             }
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
       "Address status.  The preferred(1) state indicates
       that this is a valid address that can appear as
@@ -832,13 +980,14 @@ ipv6IfLastChange OBJECT-TYPE
       a valid but deprecated address that should no longer
       be used as a source address in new communications,
       but packets addressed to such an address are
-      processed as expected. The invalid(3) state indicates
+      processed as expected.  The invalid(3) state indicates
       that this is not valid address which should not
-
       appear as the destination or source address of
-      a packet. The inaccessible(4) state indicates that
+      a packet.  The inaccessible(4) state indicates that
       the address is not accessible because the interface
-      to which this address is assigned is not operational."
+      to which this address is assigned is not operational.
+
+      This object is obsoleted by IP-MIB::ipAddressStatus."
     ::= { ipv6AddrEntry 5 }
 
  -- IPv6 Routing objects
@@ -846,23 +995,29 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6RouteNumber OBJECT-TYPE
      SYNTAX      Gauge32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The number of current ipv6RouteTable entries.
        This is primarily to avoid having to read
-       the table in order to determine this number."
+       the table in order to determine this number.
+
+       This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteNumber."
      ::= { ipv6MIBObjects 9 }
 
  ipv6DiscardedRoutes OBJECT-TYPE
      SYNTAX      Counter32
      MAX-ACCESS  read-only
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The number of routing entries which were chosen
+
         to be discarded even though they are valid.  One
         possible reason for discarding such an entry could
         be to free-up buffer space for other routing
-        entries."
+        entries.
+
+        This object is obsoleted by
+        IP-FORWARD-MIB::inetCidrRouteDiscards."
      ::= { ipv6MIBObjects 10 }
 
  -- IPv6 Routing table
@@ -870,20 +1025,25 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6RouteTable OBJECT-TYPE
      SYNTAX     SEQUENCE OF Ipv6RouteEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-       "IPv6 Routing table. This table contains
+       "IPv6 Routing table.  This table contains
        an entry for each valid IPv6 unicast route
        that can be used for packet forwarding
-       determination."
+       determination.
+
+       This table is obsoleted by IP-FORWARD-MIB::inetCidrRouteTable."
      ::= { ipv6MIBObjects 11 }
 
  ipv6RouteEntry OBJECT-TYPE
      SYNTAX     Ipv6RouteEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-             "A routing entry."
+             "A routing entry.
+
+             This entry is obsoleted by
+             IP-FORWARD-MIB::inetCidrRouteEntry."
      INDEX   { ipv6RouteDest,
                ipv6RoutePfxLength,
                ipv6RouteIndex }
@@ -909,40 +1069,46 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6RouteDest OBJECT-TYPE
      SYNTAX     Ipv6Address
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "The destination IPv6 address of this route.
        This object may not take a Multicast address
-       value."
+       value.
+
+       This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteDest."
      ::= { ipv6RouteEntry 1 }
 
  ipv6RoutePfxLength OBJECT-TYPE
      SYNTAX     INTEGER(0..128)
      UNITS      "bits"
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "Indicates the prefix length of the destination
-       address."
+       address.
+
+       This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePfxLen."
      ::= { ipv6RouteEntry 2 }
 
  ipv6RouteIndex OBJECT-TYPE
      SYNTAX     Unsigned32
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "The value which uniquely identifies the route
        among the routes to the same network layer
        destination.  The way this value is chosen is
        implementation specific but it must be unique for
        ipv6RouteDest/ipv6RoutePfxLength pair and remain
-       constant for the life of the route."
+       constant for the life of the route.
+
+       This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePolicy."
      ::= { ipv6RouteEntry 3 }
 
  ipv6RouteIfIndex OBJECT-TYPE
      SYNTAX     Ipv6IfIndexOrZero
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "The index value which uniquely identifies the local
        interface through which the next hop of this
@@ -950,18 +1116,24 @@ ipv6IfLastChange OBJECT-TYPE
        by a particular value of this index is the same
        interface as identified by the same value of
        ipv6IfIndex.  For routes of the discard type this
-       value can be zero."
+       value can be zero.
+
+       This object is obsoleted by
+       IP-FORWARD-MIB::inetCidrRouteIfIndex."
      ::= { ipv6RouteEntry 4 }
 
  ipv6RouteNextHop OBJECT-TYPE
      SYNTAX     Ipv6Address
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "On remote routes, the address of the next
        system en route;  otherwise, ::0
        ('00000000000000000000000000000000'H in ASN.1
-       string representation)."
+       string representation).
+
+       This object is obsoleted by
+       IP-FORWARD-MIB::inetCidrRouteNextHop."
      ::= { ipv6RouteEntry 5 }
 
  ipv6RouteType OBJECT-TYPE
@@ -982,16 +1154,18 @@ ipv6IfLastChange OBJECT-TYPE
 
      }
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-        "The type of route. Note that 'local(3)' refers
+        "The type of route.  Note that 'local(3)' refers
         to a route for which the next hop is the final
         destination; 'remote(4)' refers to a route for
-        which  the  next  hop is not the final
+        which the next hop is not the final
         destination; 'discard(2)' refers to a route
         indicating that packets to destinations matching
         this route are to be discarded (sometimes called
-        black-hole route)."
+        black-hole route).
+
+        This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteType."
      ::= { ipv6RouteEntry 6 }
 
  ipv6RouteProtocol OBJECT-TYPE
@@ -1017,16 +1191,18 @@ ipv6IfLastChange OBJECT-TYPE
        igrp(9)     -- InterGateway Routing Protocol
      }
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "The routing mechanism via which this route was
-       learned."
+       learned.
+
+       This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteProto."
      ::= { ipv6RouteEntry 7 }
 
  ipv6RoutePolicy OBJECT-TYPE
      SYNTAX     Integer32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "The general set of conditions that would cause the
       selection of one multipath route (set of next hops
@@ -1039,90 +1215,103 @@ ipv6IfLastChange OBJECT-TYPE
       Protocols defining 'policy' otherwise must either
       define a set of values which are valid for
       this object or must implement an integer-
-      instanced  policy table for which this object's
-      value acts as an index."
+      instanced policy table for which this object's
+      value acts as an index.
+
+      This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePolicy."
      ::= { ipv6RouteEntry 8 }
 
  ipv6RouteAge OBJECT-TYPE
      SYNTAX     Unsigned32
      UNITS      "seconds"
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The number of seconds since this route was last
         updated or otherwise determined to be correct.
         Note that no semantics of `too old' can be implied
         except through knowledge of the routing protocol
-        by which the route was learned."
+        by which the route was learned.
+
+        This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteAge."
      ::= { ipv6RouteEntry 9 }
 
  ipv6RouteNextHopRDI OBJECT-TYPE
      SYNTAX     Unsigned32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The Routing Domain ID of the Next Hop.
-        The  semantics of this object are determined by
-        the routing-protocol specified in  the  route's
-        ipv6RouteProtocol value.   When  this object is
+        The semantics of this object are determined by
+        the routing-protocol specified in the route's
+        ipv6RouteProtocol value.  When this object is
         unknown or not relevant its value should be set
-        to zero."
+        to zero.
+
+        This object is obsolete, and it has no replacement.
+        The Routing Domain ID concept did not catch on."
      ::= { ipv6RouteEntry 10 }
 
  ipv6RouteMetric OBJECT-TYPE
      SYNTAX     Unsigned32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-        "The routing metric for this route. The
+        "The routing metric for this route.  The
         semantics of this metric are determined by the
         routing protocol specified in the route's
         ipv6RouteProtocol value.  When this is unknown
         or not relevant to the protocol indicated by
         ipv6RouteProtocol, the object value should be
-        set to its maximum value (4,294,967,295)."
+        set to its maximum value (4,294,967,295).
+
+        This object is obsoleted by
+        IP-FORWARD-MIB::inetCidrRouteMetric1."
      ::= { ipv6RouteEntry 11 }
 
  ipv6RouteWeight OBJECT-TYPE
      SYNTAX     Unsigned32
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The system internal weight value for this route.
         The semantics of this value are determined by
-        the implementation specific rules. Generally,
+        the implementation specific rules.  Generally,
         within routes with the same ipv6RoutePolicy value,
         the lower the weight value the more preferred is
-        the route."
+        the route.
+
+        This object is obsoleted, and it has not been replaced."
      ::= { ipv6RouteEntry 12 }
 
  ipv6RouteInfo OBJECT-TYPE
      SYNTAX     RowPointer
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "A reference to MIB definitions specific to the
         particular routing protocol which is responsible
-        for this route, as determined by the  value
-        specified  in the route's ipv6RouteProto value.
-        If this information is not present,  its  value
+        for this route, as determined by the value
+        specified in the route's ipv6RouteProto value.
+        If this information is not present, its value
         should be set to the OBJECT ID { 0 0 },
-        which is a syntactically valid object  identifier,
+        which is a syntactically valid object identifier,
         and any implementation conforming to ASN.1
-        and the Basic Encoding Rules must  be  able  to
-        generate and recognize this value."
+        and the Basic Encoding Rules must be able to
+        generate and recognize this value.
+
+        This object is obsoleted, and it has not been replaced."
      ::= { ipv6RouteEntry 13 }
 
  ipv6RouteValid OBJECT-TYPE
      SYNTAX     TruthValue
      MAX-ACCESS read-write
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "Setting this object to the value 'false(2)' has
         the effect of invalidating the corresponding entry
         in the ipv6RouteTable object.  That is, it
         effectively disassociates the destination
-
         identified with said entry from the route
         identified with said entry.  It is an
         implementation-specific matter as to whether the
@@ -1132,7 +1321,10 @@ ipv6IfLastChange OBJECT-TYPE
         corresponds to entries not currently in use.
         Proper interpretation of such entries requires
         examination of the relevant ipv6RouteValid
-        object."
+        object.
+
+        This object is obsoleted by
+        IP-FORWARD-MIB::inetCidrRouteStatus."
      DEFVAL  { true }
      ::= { ipv6RouteEntry 14 }
 
@@ -1141,7 +1333,7 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6NetToMediaTable OBJECT-TYPE
      SYNTAX      SEQUENCE OF Ipv6NetToMediaEntry
      MAX-ACCESS  not-accessible
-     STATUS      current
+     STATUS      obsolete
      DESCRIPTION
        "The IPv6 Address Translation table used for
        mapping from IPv6 addresses to physical addresses.
@@ -1152,16 +1344,20 @@ ipv6IfLastChange OBJECT-TYPE
        for determining address equivalencies; if all
        interfaces are of this type, then the Address
        Translation table is empty, i.e., has zero
-       entries."
+       entries.
+
+       This table is obsoleted by IP-MIB::ipNetToPhysicalTable."
      ::= { ipv6MIBObjects 12 }
 
  ipv6NetToMediaEntry OBJECT-TYPE
      SYNTAX     Ipv6NetToMediaEntry
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
        "Each entry contains one IPv6 address to `physical'
-       address equivalence."
+       address equivalence.
+
+       This entry is obsoleted by IP-MIB::ipNetToPhysicalEntry."
      INDEX   { ipv6IfIndex,
                ipv6NetToMediaNetAddress }
      ::= { ipv6NetToMediaTable 1 }
@@ -1170,7 +1366,6 @@ ipv6IfLastChange OBJECT-TYPE
          ipv6NetToMediaNetAddress
              Ipv6Address,
          ipv6NetToMediaPhysAddress
-
              PhysAddress,
          ipv6NetToMediaType
              INTEGER,
@@ -1185,18 +1380,22 @@ ipv6IfLastChange OBJECT-TYPE
  ipv6NetToMediaNetAddress OBJECT-TYPE
      SYNTAX     Ipv6Address
      MAX-ACCESS not-accessible
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
         "The IPv6 Address corresponding to
-        the media-dependent `physical' address."
+        the media-dependent `physical' address.
+
+        This object is obsoleted by IP-MIB::ipNetToPhysicalNetAddress."
      ::= { ipv6NetToMediaEntry 1 }
 
  ipv6NetToMediaPhysAddress OBJECT-TYPE
      SYNTAX     PhysAddress
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-       "The media-dependent `physical' address."
+       "The media-dependent `physical' address.
+
+       This object is obsoleted by IP-MIB::ipNetToPhysicalPhysAddress."
      ::= { ipv6NetToMediaEntry 2 }
 
  ipv6NetToMediaType OBJECT-TYPE
@@ -1207,16 +1406,18 @@ ipv6IfLastChange OBJECT-TYPE
                  local(4)     -- local interface
                 }
      MAX-ACCESS read-only
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
-             "The type of the mapping. The 'dynamic(2)' type
+             "The type of the mapping.  The 'dynamic(2)' type
              indicates that the IPv6 address to physical
              addresses mapping has been dynamically
              resolved using the IPv6 Neighbor Discovery
-             protocol. The static(3)' types indicates that
+             protocol.  The static(3)' types indicates that
              the mapping has been statically configured.
              The local(4) indicates that the mapping is
-             provided for an entity's own interface address."
+             provided for an entity's own interface address.
+
+             This object is obsoleted by IP-MIB::ipNetToPhysicalType."
      ::= { ipv6NetToMediaEntry 3 }
 
 ipv6IfNetToMediaState OBJECT-TYPE
@@ -1237,29 +1438,33 @@ ipv6IfNetToMediaState OBJECT-TYPE
                            -- for some reason.
             }
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
-        "The Neighbor Unreachability Detection [8] state
+        "The Neighbor Unreachability Detection [RFC2461] state
         for the interface when the address mapping in
-        this entry is used."
+        this entry is used.
+
+        This object is obsoleted by IP-MIB::ipNetToPhysicalState."
     ::= { ipv6NetToMediaEntry 4 }
 
 ipv6IfNetToMediaLastUpdated OBJECT-TYPE
     SYNTAX      TimeStamp
     MAX-ACCESS  read-only
-    STATUS      current
+    STATUS      obsolete
     DESCRIPTION
         "The value of sysUpTime at the time this entry
         was last updated.  If this entry was updated prior
         to the last re-initialization of the local network
         management subsystem, then this object contains
-        a zero value."
+        a zero value.
+
+        This object is obsoleted by IP-MIB::ipNetToPhysicalLastUpdated."
     ::= { ipv6NetToMediaEntry 5 }
 
  ipv6NetToMediaValid OBJECT-TYPE
      SYNTAX     TruthValue
      MAX-ACCESS read-write
-     STATUS     current
+     STATUS     obsolete
      DESCRIPTION
       "Setting this object to the value 'false(2)' has
       the effect of invalidating the corresponding entry
@@ -1267,21 +1472,22 @@ ipv6IfNetToMediaLastUpdated OBJECT-TYPE
       disassociates the interface identified with said
       entry from the mapping identified with said entry.
       It is an implementation-specific matter as to
-
       whether the agent removes an invalidated entry
       from the table.  Accordingly, management stations
       must be prepared to receive tabular information
       from agents that corresponds to entries not
       currently in use.  Proper interpretation of such
       entries requires examination of the relevant
-      ipv6NetToMediaValid object."
+      ipv6NetToMediaValid object.
+
+      This object is obsoleted by IP-MIB::ipNetToPhysicalRowStatus."
      DEFVAL  { true }
      ::= { ipv6NetToMediaEntry 6 }
 
 -- definition of IPv6-related notifications.
 -- Note that we need ipv6NotificationPrefix with the 0
 -- sub-identifier to make this MIB to translate to
--- an SNMPv1 format in a reversible way. For example
+-- an SNMPv1 format in a reversible way.  For example
 -- it is needed for proxies that convert SNMPv1 traps
 -- to SNMPv2 notifications without MIB knowledge.
 
@@ -1295,13 +1501,16 @@ ipv6IfStateChange NOTIFICATION-TYPE
               ipv6IfDescr,
               ipv6IfOperStatus -- the new state of the If.
              }
-     STATUS             current
+     STATUS             obsolete
      DESCRIPTION
         "An ipv6IfStateChange notification signifies
         that there has been a change in the state of
         an ipv6 interface.  This notification should
         be generated when the interface's operational
-        status transitions to or from the up(1) state."
+        status transitions to or from the up(1) state.
+
+        This object is obsoleted by IF-MIB::linkUp
+        and IF-MIB::linkDown notifications."
      ::= { ipv6NotificationPrefix 1 }
 
 -- conformance information
@@ -1314,10 +1523,13 @@ ipv6Groups      OBJECT IDENTIFIER ::= { ipv6Conformance 2 }
 -- compliance statements
 
 ipv6Compliance MODULE-COMPLIANCE
-    STATUS  current
+    STATUS  obsolete
     DESCRIPTION
       "The compliance statement for SNMPv2 entities which
-      implement ipv6 MIB."
+      implement ipv6 MIB.
+
+      This compliance statement is obsoleted by
+      IP-MIB::ipMIBCompliance2."
     MODULE  -- this module
         MANDATORY-GROUPS { ipv6GeneralGroup,
                            ipv6NotificationGroup }
@@ -1361,7 +1573,6 @@ ipv6Compliance MODULE-COMPLIANCE
             MIN-ACCESS  read-only
             DESCRIPTION
                "An agent is not required to provide write
-
                 access to this object"
     ::= { ipv6Compliances 1 }
 
@@ -1426,18 +1637,25 @@ ipv6GeneralGroup OBJECT-GROUP
               ipv6IfNetToMediaState,
               ipv6IfNetToMediaLastUpdated,
               ipv6NetToMediaValid }
-    STATUS    current
+    STATUS    obsolete
     DESCRIPTION
          "The IPv6 group of objects providing for basic
-          management of IPv6 entities."
+
+          management of IPv6 entities.
+
+          This group is obsoleted by various groups in
+          IP-MIB."
     ::= { ipv6Groups 1 }
 
 ipv6NotificationGroup NOTIFICATION-GROUP
     NOTIFICATIONS { ipv6IfStateChange }
-    STATUS    current
+    STATUS    obsolete
     DESCRIPTION
          "The notification that an IPv6 entity is required
-          to implement."
+          to implement.
+
+          This group is obsoleted by
+          IF-MIB::linkUpDownNotificationsGroup."
     ::= { ipv6Groups 2 }
 
  END

--- a/docs/mibs/IPV6-TC.txt
+++ b/docs/mibs/IPV6-TC.txt
@@ -1,5 +1,14 @@
 IPV6-TC DEFINITIONS ::= BEGIN
 
+-- Copyright (c) 2017 IETF Trust and the persons identified as
+-- authors of the code.  All rights reserved.
+
+--   Redistribution and use in source and binary forms, with or without
+--   modification, is permitted pursuant to, and subject to the license
+--   terms contained in, the Simplified BSD License set forth in Section
+--   4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+--   (http://trustee.ietf.org/license-info).
+
 IMPORTS
      Integer32                FROM SNMPv2-SMI
      TEXTUAL-CONVENTION       FROM SNMPv2-TC;
@@ -7,49 +16,55 @@ IMPORTS
 -- definition of textual conventions
 Ipv6Address ::= TEXTUAL-CONVENTION
      DISPLAY-HINT "2x:"
-     STATUS       current
+     STATUS       obsolete
      DESCRIPTION
        "This data type is used to model IPv6 addresses.
         This is a binary string of 16 octets in network
-        byte-order."
+        byte-order.
+
+        This object is obsoleted by INET-ADDRESS-MIB::InetAddress."
      SYNTAX       OCTET STRING (SIZE (16))
 
 Ipv6AddressPrefix ::= TEXTUAL-CONVENTION
      DISPLAY-HINT "2x:"
-     STATUS       current
+     STATUS       obsolete
      DESCRIPTION
        "This data type is used to model IPv6 address
-       prefixes. This is a binary string of up to 16
-       octets in network byte-order."
+       prefixes.  This is a binary string of up to 16
+       octets in network byte-order.
+       This object is obsoleted by INET-ADDRESS-MIB::InetAddress."
      SYNTAX       OCTET STRING (SIZE (0..16))
 
 Ipv6AddressIfIdentifier ::= TEXTUAL-CONVENTION
      DISPLAY-HINT "2x:"
-     STATUS       current
+     STATUS       obsolete
      DESCRIPTION
        "This data type is used to model IPv6 address
-       interface identifiers. This is a binary string
-        of up to 8 octets in network byte-order."
+       interface identifiers.  This is a binary string
+        of up to 8 octets in network byte-order.
+
+       This object is obsoleted by IP-MIB::Ipv6AddressIfIdentifierTC."
      SYNTAX      OCTET STRING (SIZE (0..8))
 
 Ipv6IfIndex ::= TEXTUAL-CONVENTION
      DISPLAY-HINT "d"
-     STATUS       current
+     STATUS       obsolete
      DESCRIPTION
        "A unique value, greater than zero for each
        internetwork-layer interface in the managed
-       system. It is recommended that values are assigned
-       contiguously starting from 1. The value for each
+       system.  It is recommended that values are assigned
+       contiguously starting from 1.  The value for each
        internetwork-layer interface must remain constant
        at least from one re-initialization of the entity's
        network management system to the next
+       re-initialization.
 
-       re-initialization."
+       This object is obsoleted by IF-MIB::InterfaceIndex."
      SYNTAX       Integer32 (1..2147483647)
 
 Ipv6IfIndexOrZero ::= TEXTUAL-CONVENTION
      DISPLAY-HINT "d"
-     STATUS       current
+     STATUS       obsolete
      DESCRIPTION
          "This textual convention is an extension of the
          Ipv6IfIndex convention.  The latter defines
@@ -61,7 +76,9 @@ Ipv6IfIndexOrZero ::= TEXTUAL-CONVENTION
          which uses this syntax.  Examples of the usage of
          zero might include situations where interface was
          unknown, or when none or all interfaces need to be
-         referenced."
+         referenced.
+
+         This object is obsoleted by IF-MIB::InterfaceIndexOrZero."
      SYNTAX       Integer32 (0..2147483647)
 
 END

--- a/docs/mibs/IPV6-TCP-MIB.txt
+++ b/docs/mibs/IPV6-TCP-MIB.txt
@@ -7,7 +7,7 @@ IMPORTS
    Ipv6Address, Ipv6IfIndexOrZero       FROM IPV6-TC;
 
 ipv6TcpMIB MODULE-IDENTITY
-   LAST-UPDATED "9801290000Z"
+   LAST-UPDATED "201702220000Z"
    ORGANIZATION "IETF IPv6 MIB Working Group"
    CONTACT-INFO
         "       Mike Daniele
@@ -20,7 +20,25 @@ ipv6TcpMIB MODULE-IDENTITY
                 Phone:  +1 603 884 1423
                 Email:  daniele@zk3.dec.com"
    DESCRIPTION
-        "The MIB module for entities implementing TCP over IPv6."
+        "The obsolete MIB module for entities implementing TCP
+        over IPv6.  Use the TCP-MIB instead.
+
+        Copyright (c) 2017 IETF Trust and the persons identified
+        as authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with
+        or without modification, is permitted pursuant to, and
+        subject to the license terms contained in, the Simplified
+        BSD License set forth in Section 4.c of the IETF Trust's
+        Legal Provisions Relating to IETF Documents
+        (http://trustee.ietf.org/license-info)."
+   REVISION "201702220000Z"
+   DESCRIPTION
+        "Obsoleting this MIB module; it has been replaced by
+        the revised TCP-MIB (RFC 4022)."
+   REVISION "9801290000Z"
+   DESCRIPTION
+        "First revision, published as RFC 2452"
    ::= { experimental 86 }
 
 -- objects specific to TCP for IPv6
@@ -38,16 +56,18 @@ tcp      OBJECT IDENTIFIER ::= { mib-2 6 }
 ipv6TcpConnTable OBJECT-TYPE
    SYNTAX      SEQUENCE OF Ipv6TcpConnEntry
    MAX-ACCESS  not-accessible
-   STATUS      current
+   STATUS      obsolete
    DESCRIPTION
         "A table containing TCP connection-specific information,
-         for only those connections whose endpoints are IPv6 addresses."
+         for only those connections whose endpoints are IPv6 addresses.
+
+         This table is obsoleted by TCP-MIB::tcpConnectionTable."
    ::= { tcp 16 }
 
 ipv6TcpConnEntry OBJECT-TYPE
    SYNTAX      Ipv6TcpConnEntry
    MAX-ACCESS  not-accessible
-   STATUS      current
+   STATUS      obsolete
    DESCRIPTION
         "A conceptual row of the ipv6TcpConnTable containing
          information about a particular current TCP connection.
@@ -57,7 +77,9 @@ ipv6TcpConnEntry OBJECT-TYPE
 
          Note that conceptual rows in this table require an additional
          index object compared to tcpConnTable, since IPv6 addresses
-         are not guaranteed to be unique on the managed node."
+         are not guaranteed to be unique on the managed node.
+
+         This entry is obsoleted by TCP-MIB::tcpConnectionEntry."
    INDEX   { ipv6TcpConnLocalAddress,
              ipv6TcpConnLocalPort,
              ipv6TcpConnRemAddress,
@@ -67,75 +89,89 @@ ipv6TcpConnEntry OBJECT-TYPE
 
 Ipv6TcpConnEntry ::=
    SEQUENCE { ipv6TcpConnLocalAddress    Ipv6Address,
-              ipv6TcpConnLocalPort       INTEGER (0..65535),
+              ipv6TcpConnLocalPort       INTEGER,
               ipv6TcpConnRemAddress      Ipv6Address,
-              ipv6TcpConnRemPort         INTEGER (0..65535),
+              ipv6TcpConnRemPort         INTEGER,
               ipv6TcpConnIfIndex         Ipv6IfIndexOrZero,
               ipv6TcpConnState           INTEGER }
 
 ipv6TcpConnLocalAddress OBJECT-TYPE
    SYNTAX     Ipv6Address
    MAX-ACCESS not-accessible
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
-        "The local IPv6 address for this TCP connection. In
+        "The local IPv6 address for this TCP connection.  In
          the case of a connection in the listen state which
          is willing to accept connections for any IPv6
          address associated with the managed node, the value
-         ::0 is used."
+         ::0 is used.
+
+         This object is obsoleted by
+         TCP-MIB::tcpConnectionLocalAddressType."
    ::= { ipv6TcpConnEntry 1 }
 
 ipv6TcpConnLocalPort OBJECT-TYPE
    SYNTAX     INTEGER (0..65535)
    MAX-ACCESS not-accessible
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
-        "The local port number for this TCP connection."
+        "The local port number for this TCP connection.
+
+        This object is obsoleted by TCP-MIB::tcpConnectionLocalPort."
    ::= { ipv6TcpConnEntry 2 }
 
 ipv6TcpConnRemAddress OBJECT-TYPE
    SYNTAX     Ipv6Address
    MAX-ACCESS not-accessible
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
-        "The remote IPv6 address for this TCP connection."
+        "The remote IPv6 address for this TCP connection.
+
+        This object is obsoleted by TCP-MIB::tcpConnectionRemAddress."
    ::= { ipv6TcpConnEntry 3 }
 
 ipv6TcpConnRemPort OBJECT-TYPE
    SYNTAX     INTEGER (0..65535)
    MAX-ACCESS not-accessible
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
-        "The remote port number for this TCP connection."
+        "The remote port number for this TCP connection.
+
+        This object is obsoleted by TCP-MIB::tcpConnectionRemPort."
    ::= { ipv6TcpConnEntry 4 }
 
 ipv6TcpConnIfIndex OBJECT-TYPE
    SYNTAX     Ipv6IfIndexOrZero
    MAX-ACCESS not-accessible
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
         "An index object used to disambiguate conceptual rows in
          the table, since the connection 4-tuple may not be unique.
 
          If the connection's remote address (ipv6TcpConnRemAddress)
          is a link-local address and the connection's local address
-
          (ipv6TcpConnLocalAddress) is not a link-local address, this
          object identifies a local interface on the same link as
          the connection's remote link-local address.
 
          Otherwise, this object identifies the local interface that
          is associated with the ipv6TcpConnLocalAddress for this
-         TCP connection.  If such a local interface cannot be determined,
-         this object should take on the value 0.  (A possible example
-         of this would be if the value of ipv6TcpConnLocalAddress is ::0.)
+         TCP connection.  If such a local interface cannot be
+         determined, this object should take on the value 0.
+         (A possible example of this would be if the value of
+         ipv6TcpConnLocalAddress is ::0.)
 
          The interface identified by a particular non-0 value of this
          index is the same interface as identified by the same value
          of ipv6IfIndex.
 
          The value of this object must remain constant during the life
-         of the TCP connection."
+         of the TCP connection.
+
+         This object is obsoleted by the zone identifier in
+         an InetAddressIPv6z address in either
+         TCP-MIB::tcpConnectionLocalAddress or
+         TCP-MIB::tcpConnectionRemAddress."
    ::= { ipv6TcpConnEntry 5 }
 
 ipv6TcpConnState OBJECT-TYPE
@@ -153,15 +189,15 @@ ipv6TcpConnState OBJECT-TYPE
         timeWait(11),
         deleteTCB(12) }
    MAX-ACCESS read-write
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
         "The state of this TCP connection.
 
          The only value which may be set by a management station is
          deleteTCB(12).  Accordingly, it is appropriate for an agent
-         to return an error response (`badValue' for SNMPv1, 'wrongValue'
-         for SNMPv2) if a management station attempts to set this
-         object to any other value.
+         to return an error response ('badValue' for SNMPv1,
+         'wrongValue' for SNMPv2) if a management station attempts
+         to set this object to any other value.
 
          If a management station sets this object to the value
          deleteTCB(12), then this has the effect of deleting the TCB
@@ -171,7 +207,9 @@ ipv6TcpConnState OBJECT-TYPE
 
          As an implementation-specific option, a RST segment may be
          sent from the managed node to the other TCP endpoint (note
-         however that RST segments are not sent reliably)."
+         however that RST segments are not sent reliably).
+
+         This object is obsoleted by TCP-MIB::tcpConnectionState."
    ::= { ipv6TcpConnEntry 6 }
 
 --
@@ -186,26 +224,32 @@ ipv6TcpGroups      OBJECT IDENTIFIER ::= { ipv6TcpConformance 2 }
 -- compliance statements
 
 ipv6TcpCompliance MODULE-COMPLIANCE
-   STATUS  current
+   STATUS  obsolete
    DESCRIPTION
         "The compliance statement for SNMPv2 entities which
-         implement TCP over IPv6."
+         implement TCP over IPv6.
+
+         This compliance statement is obsoleted by
+         TCP-MIB::tcpMIBCompliance2."
    MODULE  -- this module
    MANDATORY-GROUPS { ipv6TcpGroup }
    ::= { ipv6TcpCompliances 1 }
 
 ipv6TcpGroup OBJECT-GROUP
    OBJECTS   { -- these are defined in this module
+
                -- ipv6TcpConnLocalAddress (not-accessible)
                -- ipv6TcpConnLocalPort (not-accessible)
                -- ipv6TcpConnRemAddress (not-accessible)
                -- ipv6TcpConnRemPort (not-accessible)
                -- ipv6TcpConnIfIndex (not-accessible)
                ipv6TcpConnState }
-   STATUS    current
+   STATUS    obsolete
    DESCRIPTION
         "The group of objects providing management of
-         TCP over IPv6."
+         TCP over IPv6.
+
+         This group is obsoleted by several groups in TCP-MIB."
    ::= { ipv6TcpGroups 1 }
 
 END

--- a/docs/mibs/IPV6-UDP-MIB.txt
+++ b/docs/mibs/IPV6-UDP-MIB.txt
@@ -7,7 +7,7 @@ IMPORTS
    Ipv6Address, Ipv6IfIndexOrZero       FROM IPV6-TC;
 
 ipv6UdpMIB MODULE-IDENTITY
-   LAST-UPDATED "9801290000Z"
+   LAST-UPDATED "201702220000Z"
    ORGANIZATION "IETF IPv6 MIB Working Group"
    CONTACT-INFO
         "               Mike Daniele
@@ -20,7 +20,25 @@ ipv6UdpMIB MODULE-IDENTITY
                 Phone:  +1 603 884 1423
                 Email:  daniele@zk3.dec.com"
    DESCRIPTION
-        "The MIB module for entities implementing UDP over IPv6."
+        "The obsolete MIB module for entities implementing UDP
+        over IPv6.  Use the UDP-MIB instead.
+
+        Copyright (c) 2017 IETF Trust and the persons
+        identified as authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms,
+        with or without modification, is permitted pursuant to,
+        and subject to the license terms contained in, the
+        Simplified BSD License set forth in Section 4.c of the IETF
+        Trust's Legal Provisions Relating to IETF Documents
+        (http://trustee.ietf.org/license-info)."
+   REVISION "201702220000Z"
+   DESCRIPTION
+        "Obsoleting this MIB module; it has been replaced by
+        the revised UDP-MIB (RFC 4113)."
+   REVISION "9801290000Z"
+   DESCRIPTION
+        "First revision, published as RFC 2454"
    ::= { experimental 87 }
 
 -- objects specific to UDP for IPv6
@@ -37,57 +55,66 @@ udp      OBJECT IDENTIFIER ::= { mib-2 7 }
 ipv6UdpTable OBJECT-TYPE
    SYNTAX      SEQUENCE OF Ipv6UdpEntry
    MAX-ACCESS  not-accessible
-   STATUS      current
+   STATUS      obsolete
    DESCRIPTION
         "A table containing UDP listener information for
-         UDP/IPv6 endpoints."
+         UDP/IPv6 endpoints.
+
+         This table is obsoleted by UDP-MIB::udpEndpointTable."
    ::= { udp 6 }
 
 ipv6UdpEntry OBJECT-TYPE
    SYNTAX      Ipv6UdpEntry
    MAX-ACCESS  not-accessible
-   STATUS      current
+   STATUS      obsolete
    DESCRIPTION
         "Information about a particular current UDP listener.
 
          Note that conceptual rows in this table require an
          additional index object compared to udpTable, since
          IPv6 addresses are not guaranteed to be unique on the
-         managed node."
+         managed node.
+
+         This entry is obsoleted by UDP-MIB::udpEndpointTable."
    INDEX   { ipv6UdpLocalAddress,
              ipv6UdpLocalPort,
              ipv6UdpIfIndex }
    ::= { ipv6UdpTable 1 }
 
 Ipv6UdpEntry ::= SEQUENCE {
+
    ipv6UdpLocalAddress    Ipv6Address,
-   ipv6UdpLocalPort       INTEGER (0..65535),
+   ipv6UdpLocalPort       INTEGER,
    ipv6UdpIfIndex         Ipv6IfIndexOrZero }
 
 ipv6UdpLocalAddress OBJECT-TYPE
    SYNTAX       Ipv6Address
    MAX-ACCESS   not-accessible
-   STATUS       current
+   STATUS       obsolete
    DESCRIPTION
         "The local IPv6 address for this UDP listener.
          In the case of a UDP listener which is willing
          to accept datagrams for any IPv6 address
          associated with the managed node, the value ::0
-         is used."
+         is used.
+
+         This object is obsoleted by UDP-MIB::udpEndpointLocalAddress."
    ::= { ipv6UdpEntry 1 }
 
 ipv6UdpLocalPort OBJECT-TYPE
     SYNTAX     INTEGER (0..65535)
     MAX-ACCESS not-accessible
-    STATUS     current
+    STATUS     obsolete
     DESCRIPTION
-        "The local port number for this UDP listener."
+        "The local port number for this UDP listener.
+
+        This object is obsoleted by UDP-MIB::udpEndpointLocalPort."
     ::= { ipv6UdpEntry 2 }
 
 ipv6UdpIfIndex OBJECT-TYPE
    SYNTAX     Ipv6IfIndexOrZero
    MAX-ACCESS   read-only
-   STATUS     current
+   STATUS     obsolete
    DESCRIPTION
         "An index object used to disambiguate conceptual rows in
          the table, since the ipv6UdpLocalAddress/ipv6UdpLocalPort
@@ -104,7 +131,12 @@ ipv6UdpIfIndex OBJECT-TYPE
          value of ipv6IfIndex.
 
          The value of this object must remain constant during
-         the life of this UDP endpoint."
+
+         the life of this UDP endpoint.
+
+         This object is obsoleted by the zone identifier in
+         an InetAddressIPv6z address in
+         UDP-MIB::udpEndpointLocalAddress."
    ::= { ipv6UdpEntry 3 }
 
 --
@@ -119,10 +151,12 @@ ipv6UdpGroups      OBJECT IDENTIFIER ::= { ipv6UdpConformance 2 }
 -- compliance statements
 
 ipv6UdpCompliance MODULE-COMPLIANCE
-   STATUS  current
+   STATUS  obsolete
    DESCRIPTION
         "The compliance statement for SNMPv2 entities which
-         implement UDP over IPv6."
+         implement UDP over IPv6.
+
+         This object is obsoleted by UDP-MIB::udpMIBCompliance2."
    MODULE  -- this module
    MANDATORY-GROUPS { ipv6UdpGroup }
    ::= { ipv6UdpCompliances 1 }
@@ -132,10 +166,12 @@ ipv6UdpGroup OBJECT-GROUP
                -- ipv6UdpLocalAddress (not-accessible)
                -- ipv6UdpLocalPort (not-accessible)
                ipv6UdpIfIndex }
-   STATUS    current
+   STATUS    obsolete
    DESCRIPTION
         "The group of objects providing management of
-         UDP over IPv6."
+         UDP over IPv6.
+
+         This group is obsoleted by several groups in UDP-MIB."
    ::= { ipv6UdpGroups 1 }
 
 END

--- a/docs/mibs/ipv6IcmpMIB.html
+++ b/docs/mibs/ipv6IcmpMIB.html
@@ -14,11 +14,11 @@ document as <b>.1.3.6.1.2.1.56</b>.
 <h3><a href="#objects_Current">Current Objects</a></h3>
 <ul>
 <li><a href="#scalar_current">Scalars</a></li>
-  <li><a href="#ipv6IfIcmpTable">ipv6IfIcmpTable</a></li>
 </ul>
 <h3><a href="#objects_Deprecated">Deprecated Objects</a></h3>
 <ul>
 <li><a href="#scalar_notcurrent">Deprecated Scalars</a></li>
+  <li><a href="#ipv6IfIcmpTable">ipv6IfIcmpTable</a></li>
 </ul>
 <h3><a href="#notifications">Notifications</a></h3>
 <h3><a href="#textconventions">Textual Conventions</a></h3>
@@ -26,6 +26,20 @@ document as <b>.1.3.6.1.2.1.56</b>.
 </ul>
 <a name="objects_Current" />
 <a name="scalar_current" />
+<h2>SCALAR OBJECTS</h2>
+<ul>
+<table>
+<tr><th>Name</th><th>Type</th><th>Access</th><th>OID</th><th>Description</th></tr>
+</table>
+</ul>
+
+<h2>TABLE OBJECTS</h2>
+<a name="objects_Deprecated" />
+  <hr />
+  <h1><font color="red">DEPRECATED OR OBSOLETE OR HISTORIC OBJECTS</font></h1>
+  <br>
+  <table class="deprecated"><tr><td>
+<a name="scalar_notcurrent" />
 <h2>SCALAR OBJECTS</h2>
 <ul>
 <table>
@@ -43,9 +57,12 @@ document as <b>.1.3.6.1.2.1.56</b>.
   <tr><td class="label">Table Description</td>
 <td>
 <pre>
-IPv6 ICMP statistics. This table contains statistics
+IPv6 ICMP statistics.  This table contains statistics
 of ICMPv6 messages that are received and sourced by
 the entity.
+
+This table is obsolete because systems were found
+not to maintain these statistics per-interface.
 </pre>
 </td>
 </tr>
@@ -60,10 +77,13 @@ the interface to which a given ICMPv6 message
 is addressed which may not be necessarily
 the input interface for the message.
 
-Similarly,  the sending interface is
+Similarly, the sending interface is
 the interface that sources a given
 ICMP message which is usually but not
 necessarily the output interface for the message.
+
+This table is obsolete because systems were found
+not to maintain these statistics per-interface.
 </pre>
 </td>
 </tr>
@@ -74,12 +94,13 @@ necessarily the output interface for the message.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -94,6 +115,9 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
@@ -103,12 +127,13 @@ the particular IPv6 interface.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInMsgs" />
 1
 <br /><b>ipv6IfIcmpInMsgs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -116,20 +141,23 @@ the particular IPv6 interface.
 <pre>
 The total number of ICMP messages received
 by the interface which includes all those
-counted by ipv6IfIcmpInErrors. Note that this
+counted by ipv6IfIcmpInErrors.  Note that this
 interface is the interface to which the
 ICMP messages were addressed which may not be
 necessarily the input interface for the messages.
+
+This object has been obsoleted by IP-MIB::icmpStatsInMsgs.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInErrors" />
 2
 <br /><b>ipv6IfIcmpInErrors</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -138,16 +166,19 @@ necessarily the input interface for the messages.
 The number of ICMP messages which the interface
 received but determined as having ICMP-specific
 errors (bad ICMP checksums, bad length, etc.).
+
+This object has been obsoleted by IP-MIB::icmpStatsInErrors.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInDestUnreachs" />
 3
 <br /><b>ipv6IfIcmpInDestUnreachs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -155,16 +186,20 @@ errors (bad ICMP checksums, bad length, etc.).
 <pre>
 The number of ICMP Destination Unreachable
 messages received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInAdminProhibs" />
 4
 <br /><b>ipv6IfIcmpInAdminProhibs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -172,17 +207,22 @@ messages received by the interface.
 <pre>
 The number of ICMP destination
 unreachable/communication administratively
+
 prohibited messages received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInTimeExcds" />
 5
 <br /><b>ipv6IfIcmpInTimeExcds</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -190,16 +230,20 @@ prohibited messages received by the interface.
 <pre>
 The number of ICMP Time Exceeded messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInParmProblems" />
 6
 <br /><b>ipv6IfIcmpInParmProblems</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -207,16 +251,20 @@ received by the interface.
 <pre>
 The number of ICMP Parameter Problem messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInPktTooBigs" />
 7
 <br /><b>ipv6IfIcmpInPktTooBigs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -224,16 +272,20 @@ received by the interface.
 <pre>
 The number of ICMP Packet Too Big messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInEchos" />
 8
 <br /><b>ipv6IfIcmpInEchos</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -241,16 +293,19 @@ received by the interface.
 <pre>
 The number of ICMP Echo (request) messages
 received by the interface.
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInEchoReplies" />
 9
 <br /><b>ipv6IfIcmpInEchoReplies</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -258,16 +313,20 @@ received by the interface.
 <pre>
 The number of ICMP Echo Reply messages received
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInRouterSolicits" />
 10
 <br /><b>ipv6IfIcmpInRouterSolicits</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -275,16 +334,20 @@ by the interface.
 <pre>
 The number of ICMP Router Solicit messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInRouterAdvertisements" />
 11
 <br /><b>ipv6IfIcmpInRouterAdvertisements</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -292,16 +355,20 @@ received by the interface.
 <pre>
 The number of ICMP Router Advertisement messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInNeighborSolicits" />
 12
 <br /><b>ipv6IfIcmpInNeighborSolicits</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -309,16 +376,19 @@ received by the interface.
 <pre>
 The number of ICMP Neighbor Solicit messages
 received by the interface.
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+       in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInNeighborAdvertisements" />
 13
 <br /><b>ipv6IfIcmpInNeighborAdvertisements</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -326,16 +396,20 @@ received by the interface.
 <pre>
 The number of ICMP Neighbor Advertisement
 messages received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInRedirects" />
 14
 <br /><b>ipv6IfIcmpInRedirects</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -343,16 +417,20 @@ messages received by the interface.
 <pre>
 The number of Redirect messages received
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInGroupMembQueries" />
 15
 <br /><b>ipv6IfIcmpInGroupMembQueries</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -360,16 +438,20 @@ by the interface.
 <pre>
 The number of ICMPv6 Group Membership Query
 messages received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInGroupMembResponses" />
 16
 <br /><b>ipv6IfIcmpInGroupMembResponses</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -377,16 +459,19 @@ messages received by the interface.
 <pre>
 The number of ICMPv6 Group Membership Response messages
 received by the interface.
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+      in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpInGroupMembReductions" />
 17
 <br /><b>ipv6IfIcmpInGroupMembReductions</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -394,16 +479,20 @@ received by the interface.
 <pre>
 The number of ICMPv6 Group Membership Reduction messages
 received by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsInPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutMsgs" />
 18
 <br /><b>ipv6IfIcmpOutMsgs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -412,16 +501,19 @@ received by the interface.
 The total number of ICMP messages which this
 interface attempted to send.  Note that this counter
 includes all those counted by icmpOutErrors.
+
+This object has been obsoleted by IP-MIB::icmpStatsOutMsgs.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutErrors" />
 19
 <br /><b>ipv6IfIcmpOutErrors</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -435,16 +527,19 @@ such as the inability of IPv6 to route the resultant
 datagram.  In some implementations there may be no
 types of error which contribute to this counter's
 value.
+
+This object has been obsoleted by IP-MIB::icmpStatsOutErrors.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutDestUnreachs" />
 20
 <br /><b>ipv6IfIcmpOutDestUnreachs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -452,16 +547,20 @@ value.
 <pre>
 The number of ICMP Destination Unreachable
 messages sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutAdminProhibs" />
 21
 <br /><b>ipv6IfIcmpOutAdminProhibs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -469,16 +568,20 @@ messages sent by the interface.
 <pre>
 Number of ICMP dest unreachable/communication
 administratively prohibited messages sent.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutTimeExcds" />
 22
 <br /><b>ipv6IfIcmpOutTimeExcds</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -486,16 +589,20 @@ administratively prohibited messages sent.
 <pre>
 The number of ICMP Time Exceeded messages sent
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutParmProblems" />
 23
 <br /><b>ipv6IfIcmpOutParmProblems</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -503,16 +610,20 @@ by the interface.
 <pre>
 The number of ICMP Parameter Problem messages
 sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutPktTooBigs" />
 24
 <br /><b>ipv6IfIcmpOutPktTooBigs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -520,16 +631,20 @@ sent by the interface.
 <pre>
 The number of ICMP Packet Too Big messages sent
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutEchos" />
 25
 <br /><b>ipv6IfIcmpOutEchos</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -537,16 +652,20 @@ by the interface.
 <pre>
 The number of ICMP Echo (request) messages sent
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutEchoReplies" />
 26
 <br /><b>ipv6IfIcmpOutEchoReplies</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -554,16 +673,20 @@ by the interface.
 <pre>
 The number of ICMP Echo Reply messages sent
 by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutRouterSolicits" />
 27
 <br /><b>ipv6IfIcmpOutRouterSolicits</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -571,16 +694,20 @@ by the interface.
 <pre>
 The number of ICMP Router Solicitation messages
 sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutRouterAdvertisements" />
 28
 <br /><b>ipv6IfIcmpOutRouterAdvertisements</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -588,16 +715,20 @@ sent by the interface.
 <pre>
 The number of ICMP Router Advertisement messages
 sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutNeighborSolicits" />
 29
 <br /><b>ipv6IfIcmpOutNeighborSolicits</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -605,16 +736,20 @@ sent by the interface.
 <pre>
 The number of ICMP Neighbor Solicitation
 messages sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutNeighborAdvertisements" />
 30
 <br /><b>ipv6IfIcmpOutNeighborAdvertisements</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -622,34 +757,42 @@ messages sent by the interface.
 <pre>
 The number of ICMP Neighbor Advertisement
 messages sent by the interface.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutRedirects" />
 31
 <br /><b>ipv6IfIcmpOutRedirects</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The number of Redirect messages sent. For
+The number of Redirect messages sent.  For
 a host, this object will always be zero,
 since hosts do not send redirects.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutGroupMembQueries" />
 32
 <br /><b>ipv6IfIcmpOutGroupMembQueries</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -657,16 +800,20 @@ since hosts do not send redirects.
 <pre>
 The number of ICMPv6 Group Membership Query
 messages sent.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutGroupMembResponses" />
 33
 <br /><b>ipv6IfIcmpOutGroupMembResponses</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -674,16 +821,20 @@ messages sent.
 <pre>
 The number of ICMPv6 Group Membership Response
 messages sent.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIcmpOutGroupMembReductions" />
 34
 <br /><b>ipv6IfIcmpOutGroupMembReductions</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -691,25 +842,14 @@ messages sent.
 <pre>
 The number of ICMPv6 Group Membership Reduction
 messages sent.
+
+This object has been obsoleted by IP-MIB::icmpMsgStatsOutPkts
+in the row corresponding to this message type.
 </pre>
 </td>
   </tr>
 </table>
 </ul>
-<a name="objects_Deprecated" />
-  <hr />
-  <h1><font color="red">DEPRECATED OR OBSOLETE OR HISTORIC OBJECTS</font></h1>
-  <br>
-  <table class="deprecated"><tr><td>
-<a name="scalar_notcurrent" />
-<h2>SCALAR OBJECTS</h2>
-<ul>
-<table>
-<tr><th>Name</th><th>Type</th><th>Access</th><th>OID</th><th>Description</th></tr>
-</table>
-</ul>
-
-<h2>TABLE OBJECTS</h2>
 
 <br>
   </table>
@@ -736,13 +876,14 @@ clause as well as the DESCRIPTION clause of the object itself.
 <table><tr class="label"><th>Name</th><th>Type</th><th>Description</th></tr>
 <tr><td><a name="Ipv6IfIndex">Ipv6IfIndex</td><td>INTEGER32</td><td><pre>A unique value, greater than zero for each
 internetwork-layer interface in the managed
-system. It is recommended that values are assigned
-contiguously starting from 1. The value for each
+system.  It is recommended that values are assigned
+contiguously starting from 1.  The value for each
 internetwork-layer interface must remain constant
 at least from one re-initialization of the entity's
 network management system to the next
+re-initialization.
 
-re-initialization.</pre></td></tr>
+This object is obsoleted by IF-MIB::InterfaceIndex.</pre></td></tr>
 </table></ul>
 
 <a name="treeview" />

--- a/docs/mibs/ipv6MIB.html
+++ b/docs/mibs/ipv6MIB.html
@@ -14,16 +14,16 @@ document as <b>.1.3.6.1.2.1.55</b>.
 <h3><a href="#objects_Current">Current Objects</a></h3>
 <ul>
 <li><a href="#scalar_current">Scalars</a></li>
+</ul>
+<h3><a href="#objects_Deprecated">Deprecated Objects</a></h3>
+<ul>
+<li><a href="#scalar_notcurrent">Deprecated Scalars</a></li>
   <li><a href="#ipv6IfTable">ipv6IfTable</a></li>
   <li><a href="#ipv6IfStatsTable">ipv6IfStatsTable</a></li>
   <li><a href="#ipv6AddrPrefixTable">ipv6AddrPrefixTable</a></li>
   <li><a href="#ipv6AddrTable">ipv6AddrTable</a></li>
   <li><a href="#ipv6RouteTable">ipv6RouteTable</a></li>
   <li><a href="#ipv6NetToMediaTable">ipv6NetToMediaTable</a></li>
-</ul>
-<h3><a href="#objects_Deprecated">Deprecated Objects</a></h3>
-<ul>
-<li><a href="#scalar_notcurrent">Deprecated Scalars</a></li>
 </ul>
 <h3><a href="#notifications">Notifications</a></h3>
 <h3><a href="#textconventions">Textual Conventions</a></h3>
@@ -35,13 +35,28 @@ document as <b>.1.3.6.1.2.1.55</b>.
 <ul>
 <table>
 <tr><th>Name</th><th>Type</th><th>Access</th><th>OID</th><th>Description</th></tr>
+</table>
+</ul>
+
+<h2>TABLE OBJECTS</h2>
+<a name="objects_Deprecated" />
+  <hr />
+  <h1><font color="red">DEPRECATED OR OBSOLETE OR HISTORIC OBJECTS</font></h1>
+  <br>
+  <table class="deprecated"><tr><td>
+<a name="scalar_notcurrent" />
+<h2>SCALAR OBJECTS</h2>
+<ul>
+<table>
+<tr><th>Name</th><th>Type</th><th>Access</th><th>OID</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6Forwarding" />
 1
 <br /><b>ipv6Forwarding</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -50,7 +65,6 @@ document as <b>.1.3.6.1.2.1.55</b>.
       </table>
 
   </td><td>ReadWrite</td>
-    <td>.1.3.6.1.2.1.55.1.1</td>
 <td>
 <pre>
 The indication of whether this entity is acting
@@ -66,62 +80,70 @@ Accordingly, it is appropriate for an agent to
 return a `wrongValue' response if a management
 station attempts to change this object to an
 inappropriate value.
+
+This object is obsoleted by IP-MIB::ipv6IpForwarding.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6DefaultHopLimit" />
 2
 <br /><b>ipv6DefaultHopLimit</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <br />Legal values:
         0 .. 255
 
   </td><td>ReadWrite</td>
-    <td>.1.3.6.1.2.1.55.1.2</td>
 <td>
 <pre>
 The default value inserted into the Hop Limit
 field of the IPv6 header of datagrams originated
 at this entity, whenever a Hop Limit value is not
 supplied by the transport layer protocol.
+
+This object is obsoleted by IP-MIB::ipv6IpDefaultHopLimit.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6Interfaces" />
 3
 <br /><b>ipv6Interfaces</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
-    <td>.1.3.6.1.2.1.55.1.3</td>
 <td>
 <pre>
 The number of IPv6 interfaces (regardless of
 their current state) present on this system.
+
+This object is obsolete; there is no direct replacement,
+but its value can be derived from the number of rows
+in the IP-MIB::ipv6InterfaceTable.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfTableLastChange" />
 4
 <br /><b>ipv6IfTableLastChange</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   TICKS
  <br>
  <a href="#TimeStamp">TimeStamp</a>
 
   </td><td>ReadOnly</td>
-    <td>.1.3.6.1.2.1.55.1.4</td>
 <td>
 <p>
 Note: this object is based on the <a href="#TimeStamp"> TimeStamp TEXTUAL-CONVENTION</a>.
@@ -129,50 +151,57 @@ Note: this object is based on the <a href="#TimeStamp"> TimeStamp TEXTUAL-CONVEN
 <pre>
 The value of sysUpTime at the time of the last
 insertion or removal of an entry in the
-ipv6IfTable. If the number of entries has been
+ipv6IfTable.  If the number of entries has been
 unchanged since the last re-initialization of
 the local network management subsystem, then this
 object contains a zero value.
+
+This object is obsoleted by
+IP-MIB::ipv6InterfaceTableLastChange.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteNumber" />
 9
 <br /><b>ipv6RouteNumber</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   GAUGE
 
   </td><td>ReadOnly</td>
-    <td>.1.3.6.1.2.1.55.1.9</td>
 <td>
 <pre>
 The number of current ipv6RouteTable entries.
 This is primarily to avoid having to read
 the table in order to determine this number.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteNumber.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6DiscardedRoutes" />
 10
 <br /><b>ipv6DiscardedRoutes</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
-    <td>.1.3.6.1.2.1.55.1.10</td>
 <td>
 <pre>
 The number of routing entries which were chosen
 to be discarded even though they are valid.  One
-possible reason for discarding such an entry could
-be to free-up buffer space for other routing
-entries.
+        possible reason for discarding such an entry could
+        be to free-up buffer space for other routing
+        entries.
+This object is obsoleted by
+        IP-FORWARD-MIB::inetCidrRouteDiscards.
 </pre>
 </td>
   </tr>
@@ -196,6 +225,8 @@ layer attachment to the layer immediately below
 
 IPv6 including internet layer 'tunnels', such as
 tunnels over IPv4 or IPv6 itself.
+
+This table is obsoleted by IP-MIB::ipv6InterfaceTable.
 </pre>
 </td>
 </tr>
@@ -204,6 +235,8 @@ tunnels over IPv4 or IPv6 itself.
 <pre>
 An interface entry containing objects
 about a particular IPv6 interface.
+
+This object is obsoleted by IP-MIB::ipv6InterfaceEntry.
 </pre>
 </td>
 </tr>
@@ -214,12 +247,13 @@ about a particular IPv6 interface.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -234,6 +268,9 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
@@ -243,12 +280,13 @@ the particular IPv6 interface.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfDescr" />
 2
 <br /><b>ipv6IfDescr</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         0 .. 255
@@ -264,16 +302,19 @@ Note: this object is based on the <a href="#DisplayString"> DisplayString TEXTUA
 A textual string containing information about the
 interface.  This string may be set by the network
 management system.
+
+This object is obsoleted by IF-MIB::ifDescr.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfLowerLayer" />
 3
 <br /><b>ipv6IfLowerLayer</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OBJECTID
  <br>
  <a href="#VariablePointer">VariablePointer</a>
@@ -288,9 +329,9 @@ This object identifies the protocol layer over
 which this network interface operates.  If this
 network interface operates over the data-link
 layer, then the value of this object refers to an
-instance of ifIndex [6]. If this network interface
+instance of ifIndex [RFC1573].  If this network interface
 operates over an IPv4 interface, the value of this
-object refers to an instance of ipAdEntAddr [3].
+object refers to an instance of ipAdEntAddr [RFC1213].
 
 If this network interface operates over another
 IPv6 interface, the value of this object refers to
@@ -298,16 +339,20 @@ an instance of ipv6IfIndex.  If this network
 interface is not currently operating over an active
 protocol layer, then the value of this object
 should be set to the OBJECT ID { 0 0 }.
+
+This object is obsolete.  The IF-STACK-TABLE may
+be used to express relationships between interfaces.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfEffectiveMtu" />
 4
 <br /><b>ipv6IfEffectiveMtu</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
@@ -316,16 +361,21 @@ should be set to the OBJECT ID { 0 0 }.
 The size of the largest IPv6 packet which can be
 sent/received on the interface, specified in
 octets.
+
+This object is obsolete.  The value of IF-MIB::ifMtu
+for the corresponding value of ifIndex represents the
+MTU of the interface.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfReasmMaxSize" />
 5
 <br /><b>ipv6IfReasmMaxSize</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
       <br />Legal values:
         0 .. 65535
@@ -336,16 +386,19 @@ octets.
 The size of the largest IPv6 datagram which this
 entity can re-assemble from incoming IPv6 fragmented
 datagrams received on this interface.
+
+This object is obsoleted by IP-MIB::ipv6InterfaceReasmMaxSize.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIdentifier" />
 6
 <br /><b>ipv6IfIdentifier</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         0 .. 8
@@ -360,21 +413,25 @@ Note: this object is based on the <a href="#Ipv6AddressIfIdentifier"> Ipv6Addres
 <pre>
 The Interface Identifier for this interface that
 is (at least) unique on the link this interface is
-        attached to. The Interface Identifier is combined
-        with an address prefix to form an interface address.
+attached to.  The Interface Identifier is combined
+with an address prefix to form an interface address.
+
 By default, the Interface Identifier is autoconfigured
-        according to the rules of the link type this
-        interface is attached to.
+according to the rules of the link type this
+interface is attached to.
+
+This object is obsoleted by IP-MIB::ipv6InterfaceIdentifier.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIdentifierLength" />
 7
 <br /><b>ipv6IfIdentifierLength</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <br />Legal values:
         0 .. 64
@@ -383,16 +440,20 @@ By default, the Interface Identifier is autoconfigured
 <td>
 <pre>
 The length of the Interface Identifier in bits.
+This object is obsolete.  It can be derived from the length
+       of IP-MIB::ipv6InterfaceIdentifier; Interface Identifiers
+       that are not an even number of octets are not supported.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfPhysicalAddress" />
 8
 <br /><b>ipv6IfPhysicalAddress</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
  <br>
  <a href="#PhysAddress">PhysAddress</a>
@@ -403,26 +464,29 @@ The length of the Interface Identifier in bits.
 Note: this object is based on the <a href="#PhysAddress"> PhysAddress TEXTUAL-CONVENTION</a>.
 </p>
 <pre>
-The interface's physical address. For example, for
+The interface's physical address.  For example, for
 an IPv6 interface attached to an 802.x link, this
-object normally contains a MAC address. Note that
+object normally contains a MAC address.  Note that
 in some cases this address may differ from the
 address of the interface's protocol sub-layer.  The
 interface's media-specific MIB must define the bit
 and byte ordering and the format of the value of
-this object. For interfaces which do not have such
+this object.  For interfaces which do not have such
 an address (e.g., a serial line), this object should
 contain an octet string of zero length.
+
+This object is obsoleted by IF-MIB::ifPhysAddress.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfAdminStatus" />
 9
 <br /><b>ipv6IfAdminStatus</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -434,23 +498,27 @@ contain an octet string of zero length.
 <td>
 <pre>
 The desired state of the interface.  When a managed
-system initializes,  all IPv6 interfaces start with
+system initializes, all IPv6 interfaces start with
 ipv6IfAdminStatus in the down(2) state.  As a result
 of either explicit management action or per
 configuration information retained by the managed
-
-system,  ipv6IfAdminStatus is then changed to
+system, ipv6IfAdminStatus is then changed to
 the up(1) state (or remains in the down(2) state).
+
+This object is obsolete.  IPv6 does not have a
+separate admin status; the admin status of the
+interface is represented by IF-MIB::ifAdminStatus.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfOperStatus" />
 10
 <br /><b>ipv6IfOperStatus</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -479,16 +547,21 @@ fault that prevents it from going to the up(1) state;
 it should remain in the notPresent(5) state if
 the interface has missing (typically, lower layer)
 components.
+
+This object is obsolete.  IPv6 does not have a
+separate operational status; the operational status of the
+interface is represented by IF-MIB::ifOperStatus.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfLastChange" />
 11
 <br /><b>ipv6IfLastChange</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   TICKS
  <br>
  <a href="#TimeStamp">TimeStamp</a>
@@ -503,9 +576,11 @@ The value of sysUpTime at the time the interface
 entered its current operational state.  If the
 current state was entered prior to the last
 re-initialization of the local network management
-
 subsystem, then this object contains a zero
 value.
+
+This object is obsolete.  The last change of
+IF-MIB::ifOperStatus is represented by IF-MIB::ifLastChange.
 </pre>
 </td>
   </tr>
@@ -521,6 +596,7 @@ value.
 <td>
 <pre>
 IPv6 interface traffic statistics.
+This table is obsoleted by the IP-MIB::ipIfStatsTable.
 </pre>
 </td>
 </tr>
@@ -529,6 +605,8 @@ IPv6 interface traffic statistics.
 <pre>
 An interface statistics entry containing objects
 at a particular IPv6 interface.
+
+This object is obsoleted by the IP-MIB::ipIfStatsEntry.
 </pre>
 </td>
 </tr>
@@ -539,12 +617,13 @@ at a particular IPv6 interface.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -559,6 +638,9 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
@@ -568,12 +650,13 @@ the particular IPv6 interface.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInReceives" />
 1
 <br /><b>ipv6IfStatsInReceives</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -581,16 +664,19 @@ the particular IPv6 interface.
 <pre>
 The total number of input datagrams received by
 the interface, including those received in error.
+
+This object is obsoleted by IP-MIB::ipIfStatsHCInReceives.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInHdrErrors" />
 2
 <br /><b>ipv6IfStatsInHdrErrors</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -601,16 +687,19 @@ errors in their IPv6 headers, including version
 number mismatch, other format errors, hop count
 exceeded, errors discovered in processing their
 IPv6 options, etc.
+
+This object is obsoleted by IP-MIB::ipIfStatsInHdrErrors.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInTooBigErrors" />
 3
 <br /><b>ipv6IfStatsInTooBigErrors</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -618,17 +707,21 @@ IPv6 options, etc.
 <pre>
 The number of input datagrams that could not be
 forwarded because their size exceeded the link MTU
-of outgoing interface.
+       of outgoing interface.
+This object is obsoleted.  It was not replicated in the
+       IP-MIB due to feedback that systems did not retain the
+       incoming interface of a packet that failed fragmentation.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInNoRoutes" />
 4
 <br /><b>ipv6IfStatsInNoRoutes</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -637,16 +730,19 @@ of outgoing interface.
 The number of input datagrams discarded because no
 route could be found to transmit them to their
 destination.
+
+This object is obsoleted by IP-MIB::ipIfStatsInNoRoutes.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInAddrErrors" />
 5
 <br /><b>ipv6IfStatsInAddrErrors</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -662,16 +758,19 @@ entities which are not IPv6 routers and therefore
 do not forward datagrams, this counter includes
 datagrams discarded because the destination address
 was not a local address.
+
+This object is obsoleted by IP-MIB::ipIfStatsInAddrErrors.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInUnknownProtos" />
 6
 <br /><b>ipv6IfStatsInUnknownProtos</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -679,21 +778,25 @@ was not a local address.
 <pre>
 The number of locally-addressed datagrams
 received successfully but discarded because of an
-unknown or unsupported protocol. This counter is
+unknown or unsupported protocol.  This counter is
 incremented at the interface to which these
+
 datagrams were addressed which might not be
 necessarily the input interface for some of
 the datagrams.
+
+This object is obsoleted by IP-MIB::ipIfStatsInUnknownProtos.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInTruncatedPkts" />
 7
 <br /><b>ipv6IfStatsInTruncatedPkts</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -701,16 +804,19 @@ the datagrams.
 <pre>
 The number of input datagrams discarded because
 datagram frame didn't carry enough data.
+
+This object is obsoleted by IP-MIB::ipIfStatsInTruncatedPkts.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInDiscards" />
 8
 <br /><b>ipv6IfStatsInDiscards</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -722,16 +828,19 @@ continued processing, but which were discarded
 (e.g., for lack of buffer space).  Note that this
 counter does not include any datagrams discarded
 while awaiting re-assembly.
+
+This object is obsoleted by IP-MIB::ipIfStatsInDiscards.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInDelivers" />
 9
 <br /><b>ipv6IfStatsInDelivers</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -743,16 +852,19 @@ This counter is incremented at the interface to
 which these datagrams were addressed which might
 not be necessarily the input interface for some of
 the datagrams.
+
+This object is obsoleted by IP-MIB::ipIfStatsHCInDelivers.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutForwDatagrams" />
 10
 <br /><b>ipv6IfStatsOutForwDatagrams</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -767,16 +879,20 @@ via this entity, and the Source-Route
 processing was successful.  Note that for
 a successfully forwarded datagram the counter
 of the outgoing interface is incremented.
+
+This object is obsoleted by
+IP-MIB::ipIfStatsHCOutForwDatagrams.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutRequests" />
 11
 <br /><b>ipv6IfStatsOutRequests</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -787,16 +903,19 @@ user-protocols (including ICMP) supplied to IPv6 in
 requests for transmission.  Note that this counter
 does not include any datagrams counted in
 ipv6IfStatsOutForwDatagrams.
+
+This object is obsoleted by IP-MIB::ipIfStatsHCOutRequests.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutDiscards" />
 12
 <br /><b>ipv6IfStatsOutDiscards</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -809,16 +928,19 @@ discarded (e.g., for lack of buffer space).  Note
 that this counter would include datagrams counted
 in ipv6IfStatsOutForwDatagrams if any such packets
 met this (discretionary) discard criterion.
+
+This object is obsoleted by IP-MIB::ipIfStatsOutDiscards.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutFragOKs" />
 13
 <br /><b>ipv6IfStatsOutFragOKs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -826,16 +948,19 @@ met this (discretionary) discard criterion.
 <pre>
 The number of IPv6 datagrams that have been
 successfully fragmented at this output interface.
+
+This object is obsoleted by IP-MIB::ipIfStatsOutFragOKs.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutFragFails" />
 14
 <br /><b>ipv6IfStatsOutFragFails</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -844,16 +969,19 @@ successfully fragmented at this output interface.
 The number of IPv6 datagrams that have been
 discarded because they needed to be fragmented
 at this output interface but could not be.
+
+This object is obsoleted by IP-MIB::ipIfStatsOutFragFails.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutFragCreates" />
 15
 <br /><b>ipv6IfStatsOutFragCreates</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -862,16 +990,19 @@ at this output interface but could not be.
 The number of output datagram fragments that have
 been generated as a result of fragmentation at
 this output interface.
+
+This object is obsoleted by IP-MIB::ipIfStatsOutFragCreates.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsReasmReqds" />
 16
 <br /><b>ipv6IfStatsReasmReqds</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -883,16 +1014,19 @@ counter is incremented at the interface to which
 these fragments were addressed which might not
 be necessarily the input interface for some of
 the fragments.
+
+This object is obsoleted by IP-MIB::ipIfStatsReasmReqds.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsReasmOKs" />
 17
 <br /><b>ipv6IfStatsReasmOKs</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -903,16 +1037,19 @@ reassembled.  Note that this counter is incremented
 at the interface to which these datagrams were
 addressed which might not be necessarily the input
 interface for some of the fragments.
+
+This object is obsoleted by IP-MIB::ipIfStatsReasmOKs.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsReasmFails" />
 18
 <br /><b>ipv6IfStatsReasmFails</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -929,16 +1066,19 @@ This counter is incremented at the interface to which
 these fragments were addressed which might not be
 necessarily the input interface for some of the
 fragments.
+
+This object is obsoleted by IP-MIB::ipIfStatsReasmFails.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsInMcastPkts" />
 19
 <br /><b>ipv6IfStatsInMcastPkts</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -946,16 +1086,19 @@ fragments.
 <pre>
 The number of multicast packets received
 by the interface
+
+This object is obsoleted by IP-MIB::ipIfStatsHCInMcastPkts.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfStatsOutMcastPkts" />
 20
 <br /><b>ipv6IfStatsOutMcastPkts</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   COUNTER
 
   </td><td>ReadOnly</td>
@@ -963,6 +1106,8 @@ by the interface
 <pre>
 The number of multicast packets transmitted
 by the interface
+
+This object is obsoleted by IP-MIB::ipIfStatsHCOutMcastPkts.
 </pre>
 </td>
   </tr>
@@ -979,6 +1124,8 @@ by the interface
 <pre>
 The list of IPv6 address prefixes of
 IPv6 interfaces.
+
+This table is obsoleted by IP-MIB::ipAddressPrefixTable.
 </pre>
 </td>
 </tr>
@@ -987,6 +1134,8 @@ IPv6 interfaces.
 <pre>
 An interface entry containing objects of
 a particular IPv6 address prefix.
+
+This entry is obsoleted by IP-MIB::ipAddressPrefixEntry.
 </pre>
 </td>
 </tr>
@@ -997,12 +1146,13 @@ a particular IPv6 address prefix.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -1017,16 +1167,20 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefix" />
 1
 <br /><b>ipv6AddrPrefix</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         0 .. 16
@@ -1040,16 +1194,18 @@ Note: this object is based on the <a href="#Ipv6AddressPrefix"> Ipv6AddressPrefi
 </p>
 <pre>
 The prefix associated with the this interface.
+This object is obsoleted by IP-MIB::ipAddressPrefixPrefix.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefixLength" />
 2
 <br /><b>ipv6AddrPrefixLength</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <br />Legal values:
         0 .. 128
@@ -1058,6 +1214,7 @@ The prefix associated with the this interface.
 <td>
 <pre>
 The length of the prefix (in bits).
+This object is obsoleted by IP-MIB::ipAddressPrefixLength.
 </pre>
 </td>
   </tr>
@@ -1067,12 +1224,13 @@ The length of the prefix (in bits).
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefixOnLinkFlag" />
 3
 <br /><b>ipv6AddrPrefixOnLinkFlag</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
  <br>
  <a href="#TruthValue">TruthValue</a>
@@ -1085,18 +1243,21 @@ Note: this object is based on the <a href="#TruthValue"> TruthValue TEXTUAL-CONV
 </p>
 <pre>
 This object has the value 'true(1)', if this
-prefix can be used  for on-link determination
+prefix can be used for on-link determination
 and the value 'false(2)' otherwise.
+
+This object is obsoleted by IP-MIB::ipAddressPrefixOnLinkFlag.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefixAutonomousFlag" />
 4
 <br /><b>ipv6AddrPrefixAutonomousFlag</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
  <br>
  <a href="#TruthValue">TruthValue</a>
@@ -1108,22 +1269,27 @@ and the value 'false(2)' otherwise.
 Note: this object is based on the <a href="#TruthValue"> TruthValue TEXTUAL-CONVENTION</a>.
 </p>
 <pre>
-Autonomous address configuration flag. When
+Autonomous address configuration flag.  When
 true(1), indicates that this prefix can be used
 for autonomous address configuration (i.e. can
 be used to form a local interface address).
 If false(2), it is not used to autoconfigure
 a local interface address.
+
+This object is obsoleted by
+
+IP-MIB::ipAddressPrefixAutonomousFlag.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefixAdvPreferredLifetime" />
 5
 <br /><b>ipv6AddrPrefixAdvPreferredLifetime</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
@@ -1138,16 +1304,20 @@ The address generated from a deprecated prefix
 should no longer be used as a source address in
 new communications, but packets received on such
 an interface are processed as expected.
+
+This object is obsoleted by
+IP-MIB::ipAddressPrefixAdvPreferredLifetime.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPrefixAdvValidLifetime" />
 6
 <br /><b>ipv6AddrPrefixAdvValidLifetime</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
@@ -1161,6 +1331,9 @@ infinity.
 The address generated from an invalidated prefix
 should not appear as the destination or source
 address of a packet.
+
+This object is obsoleted by
+IP-MIB::ipAddressPrefixAdvValidLifetime.
 </pre>
 </td>
   </tr>
@@ -1177,6 +1350,8 @@ address of a packet.
 <pre>
 The table of addressing information relevant to
 this node's interface addresses.
+
+This table is obsoleted by IP-MIB::ipAddressTable.
 </pre>
 </td>
 </tr>
@@ -1185,6 +1360,8 @@ this node's interface addresses.
 <pre>
 The addressing information for one of this
 node's interface addresses.
+
+This entry is obsoleted by IP-MIB::ipAddressEntry.
 </pre>
 </td>
 </tr>
@@ -1195,12 +1372,13 @@ node's interface addresses.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -1215,16 +1393,20 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrAddress" />
 1
 <br /><b>ipv6AddrAddress</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         16
@@ -1239,6 +1421,8 @@ Note: this object is based on the <a href="#Ipv6Address"> Ipv6Address TEXTUAL-CO
 <pre>
 The IPv6 address to which this entry's addressing
 information pertains.
+
+This object is obsoleted by IP-MIB::ipAddressAddr.
 </pre>
 </td>
   </tr>
@@ -1248,12 +1432,13 @@ information pertains.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrPfxLength" />
 2
 <br /><b>ipv6AddrPfxLength</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <br />Legal values:
         0 .. 128
@@ -1263,16 +1448,21 @@ information pertains.
 <pre>
 The length of the prefix (in bits) associated with
 the IPv6 address of this entry.
+
+This object is obsoleted by the IP-MIB::ipAddressPrefixLength
+in the row of the IP-MIB::ipAddressPrefixTable to which the
+IP-MIB::ipAddressPrefix points.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrType" />
 3
 <br /><b>ipv6AddrType</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1284,21 +1474,24 @@ the IPv6 address of this entry.
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The type of address. Note that 'stateless(1)'
+The type of address.  Note that 'stateless(1)'
 refers to an address that was statelessly
 autoconfigured; 'stateful(2)' refers to a address
 which was acquired by via a stateful protocol
 (e.g. DHCPv6, manual configuration).
+
+This object is obsoleted by IP-MIB::ipAddressOrigin.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrAnycastFlag" />
 4
 <br /><b>ipv6AddrAnycastFlag</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
  <br>
  <a href="#TruthValue">TruthValue</a>
@@ -1313,16 +1506,20 @@ Note: this object is based on the <a href="#TruthValue"> TruthValue TEXTUAL-CONV
 This object has the value 'true(1)', if this
 address is an anycast address and the value
 'false(2)' otherwise.
+
+This object is obsoleted by a value of 'anycast(2)'
+in IP-MIB::ipAddressType.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6AddrStatus" />
 5
 <br /><b>ipv6AddrStatus</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1343,13 +1540,14 @@ The deprecated(2) state indicates that this is
 a valid but deprecated address that should no longer
 be used as a source address in new communications,
 but packets addressed to such an address are
-processed as expected. The invalid(3) state indicates
+processed as expected.  The invalid(3) state indicates
 that this is not valid address which should not
-
 appear as the destination or source address of
-a packet. The inaccessible(4) state indicates that
+a packet.  The inaccessible(4) state indicates that
 the address is not accessible because the interface
 to which this address is assigned is not operational.
+
+This object is obsoleted by IP-MIB::ipAddressStatus.
 </pre>
 </td>
   </tr>
@@ -1364,10 +1562,12 @@ to which this address is assigned is not operational.
   <tr><td class="label">Table Description</td>
 <td>
 <pre>
-IPv6 Routing table. This table contains
+IPv6 Routing table.  This table contains
 an entry for each valid IPv6 unicast route
 that can be used for packet forwarding
 determination.
+
+This table is obsoleted by IP-FORWARD-MIB::inetCidrRouteTable.
 </pre>
 </td>
 </tr>
@@ -1375,6 +1575,8 @@ determination.
 <td>
 <pre>
 A routing entry.
+This entry is obsoleted by
+             IP-FORWARD-MIB::inetCidrRouteEntry.
 </pre>
 </td>
 </tr>
@@ -1385,12 +1587,13 @@ A routing entry.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteDest" />
 1
 <br /><b>ipv6RouteDest</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         16
@@ -1406,16 +1609,19 @@ Note: this object is based on the <a href="#Ipv6Address"> Ipv6Address TEXTUAL-CO
 The destination IPv6 address of this route.
 This object may not take a Multicast address
 value.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteDest.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RoutePfxLength" />
 2
 <br /><b>ipv6RoutePfxLength</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <br />Legal values:
         0 .. 128
@@ -1425,16 +1631,19 @@ value.
 <pre>
 Indicates the prefix length of the destination
 address.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePfxLen.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteIndex" />
 3
 <br /><b>ipv6RouteIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>NoAccess</td>
@@ -1446,6 +1655,8 @@ destination.  The way this value is chosen is
 implementation specific but it must be unique for
 ipv6RouteDest/ipv6RoutePfxLength pair and remain
 constant for the life of the route.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePolicy.
 </pre>
 </td>
   </tr>
@@ -1455,12 +1666,13 @@ constant for the life of the route.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteIfIndex" />
 4
 <br /><b>ipv6RouteIfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         0 .. 2147483647
@@ -1480,16 +1692,20 @@ by a particular value of this index is the same
 interface as identified by the same value of
 ipv6IfIndex.  For routes of the discard type this
 value can be zero.
+
+This object is obsoleted by
+IP-FORWARD-MIB::inetCidrRouteIfIndex.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteNextHop" />
 5
 <br /><b>ipv6RouteNextHop</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         16
@@ -1506,16 +1722,20 @@ On remote routes, the address of the next
 system en route;  otherwise, ::0
 ('00000000000000000000000000000000'H in ASN.1
 string representation).
+
+This object is obsoleted by
+IP-FORWARD-MIB::inetCidrRouteNextHop.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteType" />
 6
 <br /><b>ipv6RouteType</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1528,24 +1748,27 @@ string representation).
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The type of route. Note that 'local(3)' refers
+The type of route.  Note that 'local(3)' refers
 to a route for which the next hop is the final
 destination; 'remote(4)' refers to a route for
-which  the  next  hop is not the final
+which the next hop is not the final
 destination; 'discard(2)' refers to a route
 indicating that packets to destinations matching
 this route are to be discarded (sometimes called
 black-hole route).
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteType.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteProtocol" />
 7
 <br /><b>ipv6RouteProtocol</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1565,16 +1788,19 @@ black-hole route).
 <pre>
 The routing mechanism via which this route was
 learned.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteProto.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RoutePolicy" />
 8
 <br /><b>ipv6RoutePolicy</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
 
   </td><td>ReadOnly</td>
@@ -1591,18 +1817,21 @@ that is zero extended at the left to a 32-bit value.
 Protocols defining 'policy' otherwise must either
 define a set of values which are valid for
 this object or must implement an integer-
-instanced  policy table for which this object's
+instanced policy table for which this object's
 value acts as an index.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRoutePolicy.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteAge" />
 9
 <br /><b>ipv6RouteAge</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
@@ -1613,59 +1842,70 @@ updated or otherwise determined to be correct.
 Note that no semantics of `too old' can be implied
 except through knowledge of the routing protocol
 by which the route was learned.
+
+This object is obsoleted by IP-FORWARD-MIB::inetCidrRouteAge.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteNextHopRDI" />
 10
 <br /><b>ipv6RouteNextHopRDI</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
 <td>
 <pre>
 The Routing Domain ID of the Next Hop.
-The  semantics of this object are determined by
-the routing-protocol specified in  the  route's
-ipv6RouteProtocol value.   When  this object is
+The semantics of this object are determined by
+the routing-protocol specified in the route's
+ipv6RouteProtocol value.  When this object is
 unknown or not relevant its value should be set
 to zero.
+
+This object is obsolete, and it has no replacement.
+The Routing Domain ID concept did not catch on.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteMetric" />
 11
 <br /><b>ipv6RouteMetric</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The routing metric for this route. The
+The routing metric for this route.  The
 semantics of this metric are determined by the
 routing protocol specified in the route's
 ipv6RouteProtocol value.  When this is unknown
 or not relevant to the protocol indicated by
 ipv6RouteProtocol, the object value should be
 set to its maximum value (4,294,967,295).
+
+This object is obsoleted by
+IP-FORWARD-MIB::inetCidrRouteMetric1.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteWeight" />
 12
 <br /><b>ipv6RouteWeight</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   UNSIGNED32
 
   </td><td>ReadOnly</td>
@@ -1673,20 +1913,23 @@ set to its maximum value (4,294,967,295).
 <pre>
 The system internal weight value for this route.
 The semantics of this value are determined by
-the implementation specific rules. Generally,
+the implementation specific rules.  Generally,
 within routes with the same ipv6RoutePolicy value,
 the lower the weight value the more preferred is
 the route.
+
+This object is obsoleted, and it has not been replaced.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteInfo" />
 13
 <br /><b>ipv6RouteInfo</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OBJECTID
  <br>
  <a href="#RowPointer">RowPointer</a>
@@ -1699,24 +1942,27 @@ Note: this object is based on the <a href="#RowPointer"> RowPointer TEXTUAL-CONV
 <pre>
 A reference to MIB definitions specific to the
 particular routing protocol which is responsible
-for this route, as determined by the  value
-specified  in the route's ipv6RouteProto value.
-If this information is not present,  its  value
+for this route, as determined by the value
+specified in the route's ipv6RouteProto value.
+If this information is not present, its value
 should be set to the OBJECT ID { 0 0 },
-which is a syntactically valid object  identifier,
+which is a syntactically valid object identifier,
 and any implementation conforming to ASN.1
-and the Basic Encoding Rules must  be  able  to
+and the Basic Encoding Rules must be able to
 generate and recognize this value.
+
+This object is obsoleted, and it has not been replaced.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6RouteValid" />
 14
 <br /><b>ipv6RouteValid</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
  <br>
  <a href="#TruthValue">TruthValue</a>
@@ -1732,7 +1978,6 @@ Setting this object to the value 'false(2)' has
 the effect of invalidating the corresponding entry
 in the ipv6RouteTable object.  That is, it
 effectively disassociates the destination
-
 identified with said entry from the route
 identified with said entry.  It is an
 implementation-specific matter as to whether the
@@ -1743,6 +1988,9 @@ corresponds to entries not currently in use.
 Proper interpretation of such entries requires
 examination of the relevant ipv6RouteValid
 object.
+
+This object is obsoleted by
+IP-FORWARD-MIB::inetCidrRouteStatus.
 </pre>
 </td>
   </tr>
@@ -1767,6 +2015,8 @@ for determining address equivalencies; if all
 interfaces are of this type, then the Address
 Translation table is empty, i.e., has zero
 entries.
+
+This table is obsoleted by IP-MIB::ipNetToPhysicalTable.
 </pre>
 </td>
 </tr>
@@ -1775,6 +2025,8 @@ entries.
 <pre>
 Each entry contains one IPv6 address to `physical'
 address equivalence.
+
+This entry is obsoleted by IP-MIB::ipNetToPhysicalEntry.
 </pre>
 </td>
 </tr>
@@ -1785,12 +2037,13 @@ address equivalence.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfIndex" />
 1
 <br /><b>ipv6IfIndex</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER32
       <br />Legal values:
         1 .. 2147483647
@@ -1805,16 +2058,20 @@ Note: this object is based on the <a href="#Ipv6IfIndex"> Ipv6IfIndex TEXTUAL-CO
 <pre>
 A unique non-zero value identifying
 the particular IPv6 interface.
+
+This object is obsoleted.  In the IP-MIB,
+interfaces are simply identified by IfIndex.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6NetToMediaNetAddress" />
 1
 <br /><b>ipv6NetToMediaNetAddress</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
       <br />Legal Lengths:
         16
@@ -1829,6 +2086,8 @@ Note: this object is based on the <a href="#Ipv6Address"> Ipv6Address TEXTUAL-CO
 <pre>
 The IPv6 Address corresponding to
 the media-dependent `physical' address.
+
+This object is obsoleted by IP-MIB::ipNetToPhysicalNetAddress.
 </pre>
 </td>
   </tr>
@@ -1838,12 +2097,13 @@ the media-dependent `physical' address.
 <table>
 <tr class="label"><th>Name</th><th>Type</th><th>Access</th><th>Description</th></tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6NetToMediaPhysAddress" />
 2
 <br /><b>ipv6NetToMediaPhysAddress</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   OCTETSTR
  <br>
  <a href="#PhysAddress">PhysAddress</a>
@@ -1855,16 +2115,18 @@ Note: this object is based on the <a href="#PhysAddress"> PhysAddress TEXTUAL-CO
 </p>
 <pre>
 The media-dependent `physical' address.
+This object is obsoleted by IP-MIB::ipNetToPhysicalPhysAddress.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6NetToMediaType" />
 3
 <br /><b>ipv6NetToMediaType</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1877,24 +2139,27 @@ The media-dependent `physical' address.
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The type of the mapping. The 'dynamic(2)' type
+The type of the mapping.  The 'dynamic(2)' type
 indicates that the IPv6 address to physical
 addresses mapping has been dynamically
 resolved using the IPv6 Neighbor Discovery
-protocol. The static(3)' types indicates that
+protocol.  The static(3)' types indicates that
 the mapping has been statically configured.
 The local(4) indicates that the mapping is
 provided for an entity's own interface address.
+
+This object is obsoleted by IP-MIB::ipNetToPhysicalType.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfNetToMediaState" />
 4
 <br /><b>ipv6IfNetToMediaState</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
       <table class="enum">
       <tr><th>Value</th><th>Label/Meaning</th></tr>
@@ -1909,19 +2174,22 @@ provided for an entity's own interface address.
   </td><td>ReadOnly</td>
 <td>
 <pre>
-The Neighbor Unreachability Detection [8] state
+The Neighbor Unreachability Detection [RFC2461] state
 for the interface when the address mapping in
 this entry is used.
+
+This object is obsoleted by IP-MIB::ipNetToPhysicalState.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6IfNetToMediaLastUpdated" />
 5
 <br /><b>ipv6IfNetToMediaLastUpdated</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   TICKS
  <br>
  <a href="#TimeStamp">TimeStamp</a>
@@ -1937,16 +2205,19 @@ was last updated.  If this entry was updated prior
 to the last re-initialization of the local network
 management subsystem, then this object contains
 a zero value.
+
+This object is obsoleted by IP-MIB::ipNetToPhysicalLastUpdated.
 </pre>
 </td>
   </tr>
   <tr>
-  <td>
+  <td class="deprecated">
 <a name="ipv6NetToMediaValid" />
 6
 <br /><b>ipv6NetToMediaValid</b>
 
 </td><td>
+<font color="red">DEPRECATED</font><br />
   INTEGER
  <br>
  <a href="#TruthValue">TruthValue</a>
@@ -1964,7 +2235,6 @@ in the ipv6NetToMediaTable.  That is, it effectively
 disassociates the interface identified with said
 entry from the mapping identified with said entry.
 It is an implementation-specific matter as to
-
 whether the agent removes an invalidated entry
 from the table.  Accordingly, management stations
 must be prepared to receive tabular information
@@ -1972,25 +2242,13 @@ from agents that corresponds to entries not
 currently in use.  Proper interpretation of such
 entries requires examination of the relevant
 ipv6NetToMediaValid object.
+
+This object is obsoleted by IP-MIB::ipNetToPhysicalRowStatus.
 </pre>
 </td>
   </tr>
 </table>
 </ul>
-<a name="objects_Deprecated" />
-  <hr />
-  <h1><font color="red">DEPRECATED OR OBSOLETE OR HISTORIC OBJECTS</font></h1>
-  <br>
-  <table class="deprecated"><tr><td>
-<a name="scalar_notcurrent" />
-<h2>SCALAR OBJECTS</h2>
-<ul>
-<table>
-<tr><th>Name</th><th>Type</th><th>Access</th><th>OID</th><th>Description</th></tr>
-</table>
-</ul>
-
-<h2>TABLE OBJECTS</h2>
 
 <br>
   </table>
@@ -2013,6 +2271,9 @@ that there has been a change in the state of
 an ipv6 interface.  This notification should
 be generated when the interface's operational
 status transitions to or from the up(1) state.
+
+This object is obsoleted by IF-MIB::linkUp
+and IF-MIB::linkDown notifications.
 </pre>
 </td>
   </tr>
@@ -2038,6 +2299,27 @@ objects that use one of these definitions must follow its DESCRIPTION
 clause as well as the DESCRIPTION clause of the object itself.
 </p>
 <table><tr class="label"><th>Name</th><th>Type</th><th>Description</th></tr>
+<tr><td><a name="Ipv6IfIndex">Ipv6IfIndex</td><td>INTEGER32</td><td><pre>A unique value, greater than zero for each
+internetwork-layer interface in the managed
+system.  It is recommended that values are assigned
+contiguously starting from 1.  The value for each
+internetwork-layer interface must remain constant
+at least from one re-initialization of the entity's
+network management system to the next
+re-initialization.
+
+This object is obsoleted by IF-MIB::InterfaceIndex.</pre></td></tr>
+<tr><td><a name="PhysAddress">PhysAddress</td><td>OCTETSTR</td><td><pre>Represents media- or physical-level addresses.</pre></td></tr>
+<tr><td><a name="TruthValue">TruthValue</td><td>INTEGER<table class="enums"><tr><th>Value</th><th>Label/Meaning</th></tr><tr><td>1</td><td>true</td></tr><tr><td>2</td><td>false</td></tr></table></td><td><pre>Represents a boolean value.</pre></td></tr>
+<tr><td><a name="Ipv6Address">Ipv6Address</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 addresses.
+This is a binary string of 16 octets in network
+byte-order.
+
+This object is obsoleted by INET-ADDRESS-MIB::InetAddress.</pre></td></tr>
+<tr><td><a name="Ipv6AddressPrefix">Ipv6AddressPrefix</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 address
+prefixes.  This is a binary string of up to 16
+octets in network byte-order.
+This object is obsoleted by INET-ADDRESS-MIB::InetAddress.</pre></td></tr>
 <tr><td><a name="TimeStamp">TimeStamp</td><td>TICKS</td><td><pre>The value of the sysUpTime object at which a specific
 occurrence happened.  The specific occurrence must be
 
@@ -2052,6 +2334,26 @@ initialization, the sysUpTime object will reach 2^^32-1 and
 then increment around to zero; in this case, existing values
 of TimeStamp objects do not change.  This can lead to
 ambiguities in the value of TimeStamp objects.</pre></td></tr>
+<tr><td><a name="VariablePointer">VariablePointer</td><td>OBJECTID</td><td><pre>A pointer to a specific object instance.  For example,
+sysContact.0 or ifInOctets.3.</pre></td></tr>
+<tr><td><a name="Ipv6AddressIfIdentifier">Ipv6AddressIfIdentifier</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 address
+interface identifiers.  This is a binary string
+ of up to 8 octets in network byte-order.
+
+This object is obsoleted by IP-MIB::Ipv6AddressIfIdentifierTC.</pre></td></tr>
+<tr><td><a name="Ipv6IfIndexOrZero">Ipv6IfIndexOrZero</td><td>INTEGER32</td><td><pre>This textual convention is an extension of the
+Ipv6IfIndex convention.  The latter defines
+a greater than zero value used to identify an IPv6
+interface in the managed system.  This extension
+permits the additional value of zero.  The value
+zero is object-specific and must therefore be
+defined as part of the description of any object
+which uses this syntax.  Examples of the usage of
+zero might include situations where interface was
+unknown, or when none or all interfaces need to be
+referenced.
+
+This object is obsoleted by IF-MIB::InterfaceIndexOrZero.</pre></td></tr>
 <tr><td><a name="DisplayString">DisplayString</td><td>OCTETSTR</td><td><pre>Represents textual information taken from the NVT ASCII
 character set, as defined in pages 4, 10-11 of RFC 854.
 To summarize RFC 854, the NVT ASCII repertoire specifies:
@@ -2070,37 +2372,6 @@ To summarize RFC 854, the NVT ASCII repertoire specifies:
                 end with either 'CR LF' or 'CR NUL', but not with CR.)
 Any object defined using this syntax may not exceed 255
             characters in length.</pre></td></tr>
-<tr><td><a name="PhysAddress">PhysAddress</td><td>OCTETSTR</td><td><pre>Represents media- or physical-level addresses.</pre></td></tr>
-<tr><td><a name="Ipv6AddressPrefix">Ipv6AddressPrefix</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 address
-prefixes. This is a binary string of up to 16
-octets in network byte-order.</pre></td></tr>
-<tr><td><a name="Ipv6IfIndexOrZero">Ipv6IfIndexOrZero</td><td>INTEGER32</td><td><pre>This textual convention is an extension of the
-Ipv6IfIndex convention.  The latter defines
-a greater than zero value used to identify an IPv6
-interface in the managed system.  This extension
-permits the additional value of zero.  The value
-zero is object-specific and must therefore be
-defined as part of the description of any object
-which uses this syntax.  Examples of the usage of
-zero might include situations where interface was
-unknown, or when none or all interfaces need to be
-referenced.</pre></td></tr>
-<tr><td><a name="Ipv6IfIndex">Ipv6IfIndex</td><td>INTEGER32</td><td><pre>A unique value, greater than zero for each
-internetwork-layer interface in the managed
-system. It is recommended that values are assigned
-contiguously starting from 1. The value for each
-internetwork-layer interface must remain constant
-at least from one re-initialization of the entity's
-network management system to the next
-
-re-initialization.</pre></td></tr>
-<tr><td><a name="Ipv6Address">Ipv6Address</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 addresses.
-This is a binary string of 16 octets in network
-byte-order.</pre></td></tr>
-<tr><td><a name="TruthValue">TruthValue</td><td>INTEGER<table class="enums"><tr><th>Value</th><th>Label/Meaning</th></tr><tr><td>1</td><td>true</td></tr><tr><td>2</td><td>false</td></tr></table></td><td><pre>Represents a boolean value.</pre></td></tr>
-<tr><td><a name="Ipv6AddressIfIdentifier">Ipv6AddressIfIdentifier</td><td>OCTETSTR</td><td><pre>This data type is used to model IPv6 address
-interface identifiers. This is a binary string
- of up to 8 octets in network byte-order.</pre></td></tr>
 <tr><td><a name="RowPointer">RowPointer</td><td>OBJECTID</td><td><pre>Represents a pointer to a conceptual row.  The value is the
 name of the instance of the first accessible columnar object
 in the conceptual row.
@@ -2108,8 +2379,6 @@ in the conceptual row.
 For example, ifIndex.3 would point to the 3rd row in the
 ifTable (note that if ifIndex were not-accessible, then
 ifDescr.3 would be used instead).</pre></td></tr>
-<tr><td><a name="VariablePointer">VariablePointer</td><td>OBJECTID</td><td><pre>A pointer to a specific object instance.  For example,
-sysContact.0 or ifInOctets.3.</pre></td></tr>
 </table></ul>
 
 <a name="treeview" />


### PR DESCRIPTION
RFC8096 updates were committed to the net-snmp source tree years ago, this is catching the web pages up.

I followed the `Updating Documentation / MIBS` directions in README.web, except I only copied over the IPv6 .txt and .html files, I did not update any of the other MIBs or html files.

Something is moving the types around in the mib2c output, so a full copy would create a bunch of unnecessary churn.